### PR TITLE
Resize ingestion image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build apps
         run: |
           cd apps
-          bash build_all.sh ${{ github.event_name }}
+          bash build_all.sh
 
       - name: Test workflow dataset-ingestion
         env:

--- a/apps/build_all.sh
+++ b/apps/build_all.sh
@@ -1,7 +1,7 @@
 
 set -e
 
-(cd ../base/docker && ./build.sh $1)
+(cd ../base/docker && ./build.sh)
 
 # iterate over all directories in the apps directory
 

--- a/base/docker/build.sh
+++ b/base/docker/build.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
-
 set -e
-PUSH=${1:-"no"}
 
 IMG_NAME="aperturedata/workflows-base"
 
 # Build docker image
-if [ $PUSH == "push" ]; then
-    docker build --no-cache -t ${IMG_NAME} .
-else
-    docker pull ${IMG_NAME}
-    docker build --cache-from=${IMG_NAME} -t ${IMG_NAME} .
-fi
+docker build --no-cache -t ${IMG_NAME} .
+
 


### PR DESCRIPTION
Using the CPU index for installing pytorch before installing CLIP reduces the image size.

BUGFIX: This also ensures on each merge to main, the base image will get updated. It was lagging 2 versions of aperturedb. 