### PR TITLE
Rag path

### DIFF
--- a/apps/rag/README.md
+++ b/apps/rag/README.md
@@ -20,7 +20,7 @@ Parameters:
 * **`WF_TOKEN`**: Authorization token to use in API
 * **`WF_INPUT`**: Name of descriptorset to use
 * **`WF_LLM_PROVIDER`**: The LLM provider to use, e.g. openai, huggingface, together, groq
-* **`WF_LLM_MODEL`**: The LLM model to use, e.g. gpt-3.5-turbo, gpt-4, llama-2-7b-chat
+* **`WF_LLM_MODEL`**: The LLM model to use, e.g. gpt-3.5-turbo, gpt-4, llama-2-7b-chat; default depends on provider - see table below
 * **`WF_LLM_API_KEY`**: API key for LLM provider
 * **`WF_MODEL`**: The embedding model to use, of the form "backend model pretrained
 * **`WF_PORT`**: The port to use; default 8000. Note that this service is HTTP and expects to be wrapped by an HTTPS proxy with appropriate keys.

--- a/apps/rag/app/app.py
+++ b/apps/rag/app/app.py
@@ -12,7 +12,7 @@ from langchain_community.vectorstores import ApertureDB
 import time
 import json
 
-from llm import LLM, DEFAULT_MODEL, DEFAULT_PROVIDER
+from llm import LLM
 from embeddings import BatchEmbedder
 from embeddings import DEFAULT_MODEL as EMBEDDING_MODEL
 from rag import QAChain
@@ -263,12 +263,12 @@ def get_args(argv=[]):
                      help='The descriptorset to use')
 
     obj.add_argument('--llm_provider',
-                     help='The LLM provider to use, e.g. openai, huggingface, together, groq',
-                     default=DEFAULT_PROVIDER)
+                     help='The LLM provider to use, e.g. openai, huggingface, together, groq; default is huggingface',
+                     default=None)
 
     obj.add_argument('--llm_model',
-                     help='The LLM model to use, e.g. gpt-3.5-turbo, gpt-4, llama-2-7b-chat',
-                     default=DEFAULT_MODEL)
+                     help='The LLM model to use, e.g. gpt-3.5-turbo, gpt-4, llama-2-7b-chat; default depends on provider',
+                     default=None)
 
     obj.add_argument('--llm_api_key',
                      help='The LLM API key to use, if required by the provider',

--- a/apps/rag/app/app.py
+++ b/apps/rag/app/app.py
@@ -20,8 +20,20 @@ from context_builder import ContextBuilder
 
 logger = logging.getLogger(__name__)
 
+APP_PATH = "/rag"
 
-app = FastAPI()
+
+# Set up the root app to redirect to /rag; useful for local dev
+root_app = FastAPI()
+
+
+@root_app.get("/")
+async def redirect_to_rag():
+    """Redirect the root URL to /rag."""
+    return Response(status_code=status.HTTP_307_TEMPORARY_REDIRECT, headers={"Location": APP_PATH})
+
+# This is the main app for the RAG API
+app = FastAPI(root_path=APP_PATH)
 
 
 @app.get("/ask")
@@ -285,5 +297,6 @@ def get_args(argv=[]):
 
 
 # Unconditional because invoked via uvicorn
+root_app.mount(APP_PATH, app)
 args = get_args()
 main(args)

--- a/apps/rag/app/app.sh
+++ b/apps/rag/app/app.sh
@@ -8,7 +8,7 @@ echo "[Startup] Launching RAG API server..."
 echo "[Startup] Using Uvicorn to serve app.py on 0.0.0.0:$PORT"
 
 # Start your FastAPI app via Uvicorn
-uvicorn app:app \
+uvicorn app:root_app \
   --host 0.0.0.0 \
   --port $PORT \
   --workers ${UVICORN_WORKERS:-1} \

--- a/apps/rag/app/llm.py
+++ b/apps/rag/app/llm.py
@@ -1,5 +1,5 @@
 import aiohttp
-from typing import List, Iterator
+from typing import List, Iterator, Optional
 import os
 import logging
 import openai
@@ -16,7 +16,14 @@ HF_PRELOAD_MODELS = [
     # "llama-2-7b-chat",
 ]
 DEFAULT_PROVIDER = "huggingface"
-DEFAULT_MODEL = HF_PRELOAD_MODELS[0]
+
+# We have a different default model for each provider.
+DEFAULT_MODELS = {
+    "openai": "gpt-3.5-turbo",
+    "together": "mistralai/Mistral-7B-Instruct-v0.2",
+    "groq": "llama3-8b-8192",
+    "huggingface": HF_PRELOAD_MODELS[0],
+}
 
 
 class LLM:
@@ -157,8 +164,18 @@ class HuggingFaceLLM:
         return output[0]['generated_text']
 
 
-def load_llm(provider: str = DEFAULT_PROVIDER, model: str = DEFAULT_MODEL, api_key: str = None) -> LLM:
+def load_llm(
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: str = None
+) -> LLM:
     """Factory function to load LLM"""
+
+    if provider is None:
+        provider = DEFAULT_PROVIDER
+
+    if model is None:
+        model = DEFAULT_MODELS[provider]
 
     logger.info(f"Loading LLM: provider={provider}, model={model}")
 

--- a/apps/rag/app/static/chat.js
+++ b/apps/rag/app/static/chat.js
@@ -1,6 +1,7 @@
 let session_id = null;
 const md = window.markdownit({ breaks: true });
 let history = null;
+const app_path = "/rag";
 
 document.getElementById('chat-button').addEventListener('click', () => {
   if (!loggedIn) {
@@ -30,7 +31,7 @@ document.getElementById('chat-send').addEventListener('click', async () => {
   input.value = '';
 
   // Start the SSE connection for the response
-  let url = `/ask/stream?query=${encodeURIComponent(message)}`;
+  let url = `${app_path}/ask/stream?query=${encodeURIComponent(message)}`;
   if (history) {
     url += `&history=${encodeURIComponent(history)}`;
   }
@@ -214,7 +215,7 @@ document.getElementById('login-submit').addEventListener('click', async () => {
   const token = document.getElementById('login-token').value.trim();
   if (!token) return;
 
-  const res = await fetch("/login", {
+  const res = await fetch(`${app_path}/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token })
@@ -235,7 +236,7 @@ async function loadConfigTable() {
   }
 
   try {
-    const response = await fetch('/config');
+    const response = await fetch(`${app_path}/config`);
     if (!response.ok) {
       throw new Error('Failed to fetch config');
     }
@@ -277,7 +278,7 @@ async function setLoggedIn(value) {
       document.getElementById('logout-container').style.display = 'block';
     } else {
       console.log("Logging out...");
-      await fetch("/logout", {
+      await fetch(`${app_path}/logout`, {
         method: "POST",
         credentials: "include"
       });

--- a/apps/rag/app/static/chat.js
+++ b/apps/rag/app/static/chat.js
@@ -159,7 +159,7 @@ function updateBotMessage(text) {
 
     const senderDiv = document.createElement('div');
     senderDiv.classList.add('chat-sender');
-    senderDiv.textContent = 'Bot';
+    senderDiv.textContent = 'RAG agent';
     last.appendChild(senderDiv);
 
     const textDiv = document.createElement('div');

--- a/apps/rag/app/static/index.html
+++ b/apps/rag/app/static/index.html
@@ -3,13 +3,13 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Demo Chatbot</title>
+    <title>Demo RAG Agent</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 </head>
 
 <body>
-    <h1>ChatBot Powered by ApertureDB</h1>
+    <h1>Demo RAG Agent, Powered by ApertureDB</h1>
 
     <div id="logout-container" style="display: none;">
         <button id="logout-button">Logout</button>

--- a/apps/rag/pre_rag.sh
+++ b/apps/rag/pre_rag.sh
@@ -35,9 +35,6 @@ EXTRACT_NAME="${RUNNER_NAME}_text_extraction"
 EMBED_IMAGE="aperturedata/workflows-text-embeddings"
 EMBED_NAME="${RUNNER_NAME}_text_embeddings"
 
-RAG_IMAGE="aperturedata/workflows-rag"
-RAG_NAME="${RUNNER_NAME}_rag"
-
 
 CLEANUP=${CLEANUP:-true}
 

--- a/apps/text-embeddings/app/aperturedb_io.py
+++ b/apps/text-embeddings/app/aperturedb_io.py
@@ -191,7 +191,7 @@ class AperturedbIO:
             e = response[1]["FindDescriptorSet"]["entities"][0]
             if e["model"] != self.embedder.model_spec:
                 raise ValueError(
-                    f"Descriptor set {self.descriptorset_name} already exists with different model {e['model']}")
+                    f"Descriptor set {self.descriptorset_name} already exists with different model {e['model']}, wanted to set {self.embedder.model_spec}")
             if e["model_fingerprint"] != self.embedder.fingerprint_hash():
                 raise ValueError(
                     f"Descriptor set {self.descriptorset_name} already exists with different fingerprint {e['model_fingerprint']}")


### PR DESCRIPTION
* Move all RAG app paths under `/rag` because of the way infra handles HTTPS reverse proxy.
* Change default LLM model to depend on provider