### PR TITLE
Remove argv from parse_args

### DIFF
--- a/apps/rag/app/app.py
+++ b/apps/rag/app/app.py
@@ -292,7 +292,7 @@ def get_args(argv=[]):
                      default=8000,
                      type=int)
 
-    params = obj.parse_args(argv)
+    params = obj.parse_args()
     return params
 
 


### PR DESCRIPTION
Trying to resolve error:
```
File "/app/app.py", line 301, in <module>
    args = get_args()
  File "/app/app.py", line 295, in get_args
    params = obj.parse_args(argv)
  File "/app/wf_argparse.py", line 84, in parse_args
    self.check_envars()
  File "/app/wf_argparse.py", line 80, in check_envars
    assert not unused_envars, "Unused environment variables found: " + \
AssertionError: Unused environment variables found: WF_LOGS_AWS_BUCKET, WF_LOGS_AWS_CREDENTIALS
App Done.
```