### PR TITLE
Fix build order

### DIFF
--- a/apps/build_all.sh
+++ b/apps/build_all.sh
@@ -1,16 +1,46 @@
 
 set -e
 
-# STart by changing to the directory of this script
+# Start by changing to the directory of this script
 DIR=$(dirname $(readlink -f $0))
 cd $DIR
 
-(cd ../base/docker && ./build.sh)
+# We have dependencies between workflows, so we need to build them in a 
+# specific order. We have three types of workflows:
+# 1. Base workflow: This is the base image that all other workflows depend on
+# 2. Normal workflows: These workflows depend only on the base workflow
+# 3. Meta workflows: These workflows that depend on other (normal) workflows
 
-# iterate over all directories in the apps directory
+BASE_WORKFLOW_DIRS=("../base/docker")
+META_WORKFLOWS=("crawl-to-rag")
 
+ALL_WORKFLOWS=()
+ALL_WORKFLOWS+=("${BASE_WORKFLOW_DIRS[@]}")
+
+# First assemble a list of normal workflows
 for d in ../apps/* ; do
   if [ -d "$d" ]; then
-    (cd $d && ./build.sh)
+    dir_name=$(basename "$d")
+    is_meta=false
+    for meta in "${META_WORKFLOWS[@]}"; do
+      if [ "$dir_name" == "$meta" ]; then
+        is_meta=true
+        break
+      fi
+    done
+    if ! $is_meta; then
+      ALL_WORKFLOWS+=("$dir_name")
+    fi
+  fi
+done
+# Now append the meta-workflows to the list
+ALL_WORKFLOWS+=("${META_WORKFLOWS[@]}")
+
+echo "Building the following workflows in order: ${ALL_WORKFLOWS[@]}"
+# Now build everything in order
+for name in "${ALL_WORKFLOWS[@]}"; do
+  echo "Building $name"
+  if [ -d "$name" ]; then
+    (cd $name && ./build.sh)
   fi
 done


### PR DESCRIPTION
crawl-to-rag is a "meta workflow" that assembles multiple other workflows into one, using docker tricks. This means that it has to be built last, or it won't incorporate changes to the other workflows.