### PR TITLE
Stricter queries for counting hq stuff.

### DIFF
--- a/apps/dataset-ingestion/app/build_faces/validate_db.py
+++ b/apps/dataset-ingestion/app/build_faces/validate_db.py
@@ -51,6 +51,7 @@ count_queries = [
         [{
             "FindImage":{
                 "constraints":{
+                    "celebahq_id" : ["!=", None],
                     "Blurry" : ["==", None]
                 },
                 "results":{
@@ -60,6 +61,9 @@ count_queries = [
         }],
         [{
             "FindPolygon":{
+                "constraints":{
+                    "celebahqmask_id" : ["!=", None]
+                },
                 "results":{
                     "count": True
                 }
@@ -67,6 +71,9 @@ count_queries = [
         }],
         [{
             "FindBoundingBox":{
+                "constraints":{
+                    "celebahqbbox_id" : ["!=", None]
+                },
                 "results":{
                     "count": True
                 }


### PR DESCRIPTION
Ensures that counting is relevant in celeba's HQ images, polygons and Bboxes.

Adresses #64 

TODO:
Another issue is that we do not run faces ingestion so much in CI, and we run cron jobs on a clean slate, how to we subject this to more scrutiny?