### PR TITLE
Add RAG notebook

### DIFF
--- a/apps/jupyterlab/app/rag.ipynb
+++ b/apps/jupyterlab/app/rag.ipynb
@@ -41,23 +41,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 61,
    "id": "9809189a",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using database host: localhost:8000\n"
+     "ename": "ValueError",
+     "evalue": "DB_HOST_PUBLIC environment variable is not set. Please set it to your database host.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[61], line 4\u001b[0m\n\u001b[1;32m      2\u001b[0m DB_HOST \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mgetenv(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mDB_HOST_PUBLIC\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m DB_HOST:\n\u001b[0;32m----> 4\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mDB_HOST_PUBLIC environment variable is not set. Please set it to your database host.\u001b[39m\u001b[38;5;124m\"\u001b[39m)    \n\u001b[1;32m      5\u001b[0m API_URL \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhttps://\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mDB_HOST\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/rag\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUsing API URL: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mAPI_URL\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mValueError\u001b[0m: DB_HOST_PUBLIC environment variable is not set. Please set it to your database host."
      ]
     }
    ],
    "source": [
     "# Assign DB_HOST to first environment variable in list DB_HOST_PUBLIC, DB_HOST\n",
-    "DB_HOST = os.getenv('DB_HOST_PUBLIC') or 'localhost:8000'\n",
-    "print(f\"Using database host: {DB_HOST}\")\n",
-    "API_URL = f'http://{DB_HOST}/rag'\n",
+    "DB_HOST = os.getenv('DB_HOST_PUBLIC')\n",
+    "if not DB_HOST:\n",
+    "    raise ValueError(\"DB_HOST_PUBLIC environment variable is not set. Please set it to your database host.\")    \n",
+    "API_URL = f'https://{DB_HOST}/rag'\n",
+    "print(f\"Using API URL: {API_URL}\")\n",
     "\n",
     "# Input API_KEY from terminal as password\n",
     "API_KEY = getpass.getpass('Enter your API key: ')"

--- a/apps/jupyterlab/app/rag.ipynb
+++ b/apps/jupyterlab/app/rag.ipynb
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "02828f12",
    "metadata": {},
    "outputs": [
@@ -236,7 +236,6 @@
     "        return\n",
     "\n",
     "    data = response.json()\n",
-    "    print(f\"API response: {data}\")\n",
     "    old_history = summary_history\n",
     "    summary_history = data.get(\"history\", summary_history)\n",
     "\n",

--- a/apps/jupyterlab/app/rag.ipynb
+++ b/apps/jupyterlab/app/rag.ipynb
@@ -41,28 +41,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "id": "9809189a",
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "DB_HOST_PUBLIC environment variable is not set. Please set it to your database host.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[61], line 4\u001b[0m\n\u001b[1;32m      2\u001b[0m DB_HOST \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mgetenv(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mDB_HOST_PUBLIC\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m DB_HOST:\n\u001b[0;32m----> 4\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mDB_HOST_PUBLIC environment variable is not set. Please set it to your database host.\u001b[39m\u001b[38;5;124m\"\u001b[39m)    \n\u001b[1;32m      5\u001b[0m API_URL \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhttps://\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mDB_HOST\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/rag\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUsing API URL: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mAPI_URL\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[0;31mValueError\u001b[0m: DB_HOST_PUBLIC environment variable is not set. Please set it to your database host."
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using API URL: http://localhost:8000/rag\n"
      ]
     }
    ],
    "source": [
-    "# Assign DB_HOST to first environment variable in list DB_HOST_PUBLIC, DB_HOST\n",
+    "# Assign DB_HOST from DB_HOST_PUBLIC\n",
     "DB_HOST = os.getenv('DB_HOST_PUBLIC')\n",
-    "if not DB_HOST:\n",
-    "    raise ValueError(\"DB_HOST_PUBLIC environment variable is not set. Please set it to your database host.\")    \n",
-    "API_URL = f'https://{DB_HOST}/rag'\n",
+    "\n",
+    "if DB_HOST:\n",
+    "    API_URL = f'https://{DB_HOST}/rag'\n",
+    "else:\n",
+    "    API_URL = 'http://localhost:8000/rag'\n",
+    "\n",
     "print(f\"Using API URL: {API_URL}\")\n",
     "\n",
     "# Input API_KEY from terminal as password\n",
@@ -82,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 63,
    "id": "99837ea1",
    "metadata": {},
    "outputs": [
@@ -153,14 +152,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 64,
    "id": "02828f12",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2d171615aec4559a9646f4a02db4b8b",
+       "model_id": "e2951cd206a348b499519dc936c37fa7",
        "version_major": 2,
        "version_minor": 0
       },

--- a/apps/jupyterlab/app/rag.ipynb
+++ b/apps/jupyterlab/app/rag.ipynb
@@ -1,0 +1,19 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bb3406b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/apps/jupyterlab/app/rag.ipynb
+++ b/apps/jupyterlab/app/rag.ipynb
@@ -1,17 +1,284 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "9743e501",
+   "metadata": {},
+   "source": [
+    "# RAG Workflow Demonstration\n",
+    "\n",
+    "If you run the [Website Chatbot](https://docs.aperturedata.io/workflows/crawl_to_rag) workflow, you can use this notebook to test the results by sending in some natural language questions and seeing the results.\n",
+    "\n",
+    "## Import some modules we will need"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "9bb3406b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "import IPython.display as display\n",
+    "from ipywidgets import Textarea, Button, VBox, Checkbox, Output\n",
+    "import os\n",
+    "import getpass\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf0b5dc8",
+   "metadata": {},
+   "source": [
+    "## Work out how to contact the RAG workflow\n",
+    "\n",
+    "This assumes that you are running this notebook as a workflow on the same instance.\n",
+    "You will be asked to enter the token that you set for your RAG endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "9809189a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using database host: localhost:8000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Assign DB_HOST to first environment variable in list DB_HOST_PUBLIC, DB_HOST\n",
+    "DB_HOST = os.getenv('DB_HOST_PUBLIC') or 'localhost:8000'\n",
+    "print(f\"Using database host: {DB_HOST}\")\n",
+    "API_URL = f'http://{DB_HOST}/rag'\n",
+    "\n",
+    "# Input API_KEY from terminal as password\n",
+    "API_KEY = getpass.getpass('Enter your API key: ')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91f628c8",
+   "metadata": {},
+   "source": [
+    "## Ensure the server is ready\n",
+    "\n",
+    "It may take a few minutes for the workflow to crawl the website, extract and segment the text, generate embeddings, and be ready to respond to queries.\n",
+    "This step checks to see if the RAG service is ready and prints out the configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "99837ea1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for server to become ready...\n",
+      "Attempt 1: Checking server readiness at http://localhost:8000/rag/config\n",
+      "Server is ready.\n",
+      "Configuration: {\n",
+      "  \"llm_provider\": \"cohere\",\n",
+      "  \"llm_model\": \"command-r-plus\",\n",
+      "  \"embedding_model\": \"openclip ViT-B-32 laion2b_s34b_b79k\",\n",
+      "  \"input\": \"crawl-to-rag7\",\n",
+      "  \"n_documents\": 4,\n",
+      "  \"host\": \"workflow-test-i8ewnkjd.farm0000.cloud.aperturedata.io\",\n",
+      "  \"count\": 766,\n",
+      "  \"ready\": true\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def wait_until_ready(api_base: str, api_key: str, delay: float = 5.0, max_tries: int = 60):\n",
+    "    print(\"Waiting for server to become ready...\")\n",
+    "    tries = 0\n",
+    "    headers = {\n",
+    "        'Authorization': f'Bearer {api_key}',\n",
+    "        'Content-Type': 'application/json'\n",
+    "    }\n",
+    "    while tries < max_tries:\n",
+    "        try:\n",
+    "            url = f\"{api_base}/config\"\n",
+    "            print(f\"Attempt {tries+1}: Checking server readiness at {url}\")\n",
+    "            r = requests.get(url, timeout=2, headers=headers)\n",
+    "            if r.status_code == 200:\n",
+    "                config = r.json()\n",
+    "                if 'ready' not in config or config.get(\"ready\") == True:\n",
+    "                    print(\"Server is ready.\")\n",
+    "                    return config  # Optional: you can return the config for inspection\n",
+    "                else:\n",
+    "                    print(f\"Server reports not ready (try {tries+1})\")\n",
+    "            else:\n",
+    "                print(f\"Received status code {r.status_code}\")\n",
+    "        except Exception as e:\n",
+    "            print(f\"Error contacting server (try {tries+1}): {e}\")\n",
+    "        tries += 1\n",
+    "        time.sleep(delay)\n",
+    "\n",
+    "    raise RuntimeError(\"Server did not become ready in time.\")\n",
+    "\n",
+    "\n",
+    "config = wait_until_ready(API_URL, API_KEY)\n",
+    "print(\"Configuration:\", json.dumps(config, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16c02496",
+   "metadata": {},
+   "source": [
+    "## Now ask questions\n",
+    "\n",
+    "This demonstration uses the non-streaming API, so it may take a few moments for the results to appear.\n",
+    "This reflects the time it takes for the LLM to stop sending output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "02828f12",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2d171615aec4559a9646f4a02db4b8b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Textarea(value='', layout=Layout(height='100px', width='100%'), placeholder='Enter your questio…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "summary_history = \"\"\n",
+    "\n",
+    "query_input = Textarea(placeholder=\"Enter your question here...\", layout={'width': '100%', 'height': '100px'})\n",
+    "run_button = Button(description=\"Ask\", button_style='primary')\n",
+    "output_area = Output()\n",
+    "\n",
+    "def render_markdown_result(query, answer, rewritten_query, documents, old_history, new_history):\n",
+    "    doc_md = \"\"\n",
+    "    for i, doc in enumerate(documents):\n",
+    "        url = doc.get(\"url\", f\"Document {i+1}\")\n",
+    "        text = doc.get(\"page_content\", \"\")[:1000]\n",
+    "        doc_md += f\"<details><summary><b>{url}</b></summary>\\n\\n```\\n{text}\\n```\\n</details>\\n\\n\"\n",
+    "    \n",
+    "    return f\"\"\"\n",
+    "## User Query\n",
+    "{query}\n",
+    "\n",
+    "## Previous Summary\n",
+    "{old_history}\n",
+    "\n",
+    "## Rewritten Query\n",
+    "\n",
+    "{rewritten_query}\n",
+    "\n",
+    "## Answer\n",
+    "{answer}\n",
+    "\n",
+    "## Source Documents\n",
+    "{doc_md}\n",
+    "\n",
+    "## Updated Summary\n",
+    "{new_history}\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "def on_button_click(_):\n",
+    "    global summary_history\n",
+    "    output_area.clear_output()\n",
+    "    query = query_input.value.strip()\n",
+    "\n",
+    "    if not query:\n",
+    "        with output_area:\n",
+    "            print(\"Please enter a query.\")\n",
+    "        return\n",
+    "\n",
+    "    payload = {\n",
+    "        \"query\": query,\n",
+    "        \"history\": summary_history\n",
+    "    }\n",
+    "\n",
+    "    headers = {\n",
+    "        'Authorization': f'Bearer {API_KEY}',\n",
+    "        'Content-Type': 'application/json'\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "    response = requests.post(f\"{API_URL}/ask\", json=payload, headers=headers)\n",
+    "\n",
+    "    if response.status_code != 200:\n",
+    "        with output_area:\n",
+    "            print(f\"Error: {response.status_code}\\n{response.text}\")\n",
+    "        return\n",
+    "\n",
+    "    data = response.json()\n",
+    "    print(f\"API response: {data}\")\n",
+    "    old_history = summary_history\n",
+    "    summary_history = data.get(\"history\", summary_history)\n",
+    "\n",
+    "    markdown_output = render_markdown_result(\n",
+    "        query=query,\n",
+    "        old_history=old_history or \"None\",\n",
+    "        answer=data.get(\"answer\", \"—\"),\n",
+    "        rewritten_query=data.get(\"rewritten_query\", \"—\"),\n",
+    "        documents=data.get(\"documents\", []),\n",
+    "        new_history=summary_history\n",
+    "    )\n",
+    "\n",
+    "    with output_area:\n",
+    "        display.display(display.Markdown(markdown_output))\n",
+    "\n",
+    "\n",
+    "run_button.on_click(on_button_click)\n",
+    "ui = VBox([query_input, run_button, output_area])\n",
+    "display.display(ui)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bb3406b",
+   "id": "02fa0f9d",
    "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a new notebook intended to demonstrate the RAG workflow. It works in local testing, but obviously I have not yet been able to test it running as part of the cloud portal.

This notebook uses only the non-streaming interface, which simplifies the implementation greatly, but is a choice we might want to revisit.