### PR TITLE
Label images; add comments; tidy action logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Read and bump version
         id: bump
         run: |
@@ -44,16 +47,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-version, read-version]
     outputs:
-      version: ${{ needs.generate-version.outputs.version || needs.read-version.outputs.version }}
+      version: ${{ steps.set.outputs.version }}
     steps:
-      - name: Log selected version
+      - name: Selected a new version
+        id: set
         run: |
-          VERSION="${{ needs.generate-version.outputs.version || needs.read-version.outputs.version }}"
+          VERSION="${{ needs.generate-version.outputs.version }}"
           if [ -z "$VERSION" ]; then
-            echo "No version available from generate-version or read-version"
+            VERSION="${{ needs.read-version.outputs.version }}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "No version found. Exiting."
             exit 1
           fi
           echo "Using version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   build-base:
     needs: get-version
@@ -194,7 +202,6 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
     env:
       VERSION: ${{ needs.generate-version.outputs.version }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Write updated version to Github variable
@@ -214,11 +221,12 @@ jobs:
         env:
           SHA: ${{ github.sha }}
         run: |
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           curl -s -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
                 -X POST \
                 https://api.github.com/repos/${{ github.repository }}/commits/$SHA/comments \
-                -d "{\"body\": \"Built and published Docker images for version \`$VERSION\`.  [View workflow run](https://github.com/OWNER/REPO/actions/runs/${{ github.run_id }})\"}"
+                -d "{\"body\": \"Built and published Docker images for version \`$VERSION\`.  [View workflow run]($RUN_URL)\"}"
 
       - name: Extract PR number from squash commit
         id: find_pr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,51 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - name: Read and bump version
+        id: bump
+        run: |
+          VERSION=$(scripts/increment_version.sh "${{ vars.VERSION }}")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
+  read-version:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+    steps:
+      - name: Use PR number and short SHA as version
+        id: read
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          VERSION="pr-${{ github.event.number }}-${SHORT_SHA}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  get-version:
+    runs-on: ubuntu-latest
+    needs: [generate-version, read-version]
+    outputs:
+      version: ${{ needs.generate-version.outputs.version || needs.read-version.outputs.version }}
+    steps:
+      - name: Log selected version
+        run: |
+          VERSION="${{ needs.generate-version.outputs.version || needs.read-version.outputs.version }}"
+          if [ -z "$VERSION" ]; then
+            echo "No version available from generate-version or read-version"
+            exit 1
+          fi
+          echo "Using version: $VERSION"
+
   build-base:
+    needs: get-version
     runs-on:
       - ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,73 +80,8 @@ jobs:
           name: workflows-base
           path: ${{ runner.temp }}/workflows-base.tar
 
-  build-test-meta:
-    needs:
-      - build-base
-
-    runs-on:
-      - deployer
-      - self-hosted
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: workflows-base
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/workflows-base.tar
-          docker image ls -a
-
-      - uses: actions/checkout@v3
-
-      - uses: aperture-data/common_job_steps@v1
-        with:
-          registry_username: ${{ fromJson(secrets.DOCKERHUB).username }}
-          registry_password: ${{ fromJson(secrets.DOCKERHUB).password }}
-
-
-      - name: Test meta workflow
-        env:
-          CLEANUP: "true"
-          WF_LOGS_AWS_CREDENTIALS: ${{ secrets.WF_LOGS_AWS_CREDENTIALS }}
-          WF_DATA_SOURCE_GCP_BUCKET: ${{ secrets.WF_DATA_SOURCE_GCP_BUCKET }}
-        run: |
-          cd apps/crawl-to-rag
-          bash test.sh
-
-      - name: Increment version
-        # Only increment version when merged to main, after builds succeed
-        if: github.event_name == 'push'
-        env:
-          VERSION: ${{ vars.RAG_VERSION }}
-        id: bump-version
-        run: |
-          NEW_VERSION=$(scripts/increment_version.sh ${VERSION})
-          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
-          curl --silent --show-error --fail --location --request PATCH \
-            --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/variables/RAG_VERSION \
-            -d "{\"value\":\"${NEW_VERSION}\"}"
-
-
-      - name: Push to docker (on main)
-        # Only push to docker when merged to main
-        # Pushing base to docker should be no-op after the first time
-        if: github.event_name == 'push'
-        run: |
-          export VERSION=${{ steps.bump-version.outputs.version }}
-          echo "Using version $VERSION"
-          docker tag aperturedata/workflows-crawl-to-rag aperturedata/workflows-crawl-to-rag:$VERSION
-          docker push aperturedata/workflows-crawl-to-rag:$VERSION
-
-
   build-test-apps:
-    needs:
-      - build-base
+    needs: [ build-base, get-version ]
 
     strategy:
       matrix:
@@ -123,6 +100,9 @@ jobs:
         ]
     runs-on:
       - ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-version.outputs.version }}
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -151,29 +131,115 @@ jobs:
           cd apps/${{ matrix.app }}
           bash test.sh || bash build.sh
 
-      - name: Increment version
-        # Only increment version when merged to main, after builds succeed
-        if: github.event_name == 'push'
-        env:
-          VERSION: ${{ vars.VERSION }}
-        id: bump-version
+      - name: Push to docker (on main)
+        # Only push to docker when merged to main
+        # Pushing base to docker should be no-op after the first time
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          NEW_VERSION=$(scripts/increment_version.sh ${VERSION})
-          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          docker tag aperturedata/workflows-base aperturedata/workflows-base:$VERSION
+          docker push aperturedata/workflows-base:$VERSION
+          docker tag aperturedata/workflows-${{ matrix.app }} aperturedata/workflows-${{ matrix.app }}:$VERSION
+          docker push aperturedata/workflows-${{ matrix.app }}:$VERSION
+
+  build-test-meta:
+    needs: [build-base, get-version, build-test-apps]
+
+    runs-on:
+      - deployer
+      - self-hosted
+
+    env:
+      VERSION: ${{ needs.get-version.outputs.version  }}
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workflows-base
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/workflows-base.tar
+          docker image ls -a
+
+      - uses: actions/checkout@v3
+
+      - uses: aperture-data/common_job_steps@v1
+        with:
+          registry_username: ${{ fromJson(secrets.DOCKERHUB).username }}
+          registry_password: ${{ fromJson(secrets.DOCKERHUB).password }}
+
+      - name: Test meta workflow
+        env:
+          CLEANUP: "true"
+          WF_LOGS_AWS_CREDENTIALS: ${{ secrets.WF_LOGS_AWS_CREDENTIALS }}
+          WF_DATA_SOURCE_GCP_BUCKET: ${{ secrets.WF_DATA_SOURCE_GCP_BUCKET }}
+        run: |
+          cd apps/crawl-to-rag
+          bash test.sh
+
+      - name: Push to docker (on main)
+        # Only push to docker when merged to main
+        # Pushing base to docker should be no-op after the first time
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "Using version $VERSION"
+          docker tag aperturedata/workflows-crawl-to-rag aperturedata/workflows-crawl-to-rag:$VERSION
+          docker push aperturedata/workflows-crawl-to-rag:$VERSION
+
+  update-version:
+    needs: [build-test-meta, build-test-apps, generate-version]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+    env:
+      VERSION: ${{ needs.generate-version.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Write updated version to Github variable
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "Missing version for update."
+            exit 1
+          fi
           curl --silent --show-error --fail --location --request PATCH \
             --header "Accept: application/vnd.github+json" \
             --header "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/variables/VERSION \
-            -d "{\"value\":\"${NEW_VERSION}\"}"
+            -d "{\"value\":\"${VERSION}\"}"
 
-      - name: Push to docker (on main)
-        # Only push to docker when merged to main
-        # Pushing base to docker should be no-op after the first time
-        if: github.event_name == 'push'
+      - name: Comment on commit with version
+        env:
+          SHA: ${{ github.sha }}
         run: |
-          export VERSION=${{ steps.bump-version.outputs.version }}
-          docker tag aperturedata/workflows-base aperturedata/workflows-base:$VERSION
-          docker push aperturedata/workflows-base:$VERSION
-          docker tag aperturedata/workflows-${{ matrix.app }} aperturedata/workflows-${{ matrix.app }}:$VERSION
-          docker push aperturedata/workflows-${{ matrix.app }}:$VERSION
+          curl -s -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -X POST \
+                https://api.github.com/repos/${{ github.repository }}/commits/$SHA/comments \
+                -d "{\"body\": \"Built and published Docker images for version \`$VERSION\`.  [View workflow run](https://github.com/OWNER/REPO/actions/runs/${{ github.run_id }})\"}"
+
+      - name: Extract PR number from squash commit
+        id: find_pr
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(git log -1 --pretty=%B | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+          echo "Found PR number: $PR_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: steps.find_pr.outputs.pr_number != ''
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ steps.find_pr.outputs.pr_number }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY=$(jq -nc --arg ver "$VERSION" --arg run_url "$RUN_URL" '{
+            body: "Docker images for version \($ver) were built and pushed after this PR was merged.  [View workflow run](\($run_url))"
+          }')
+
+          curl -s -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments \
+            -d "$BODY"

--- a/apps/crawl-to-rag/build.sh
+++ b/apps/crawl-to-rag/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/crawl-website/build.sh
+++ b/apps/crawl-website/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/dataset-ingestion/build.sh
+++ b/apps/dataset-ingestion/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/embeddings-extraction/build.sh
+++ b/apps/embeddings-extraction/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/example/build.sh
+++ b/apps/example/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/face-detection/build.sh
+++ b/apps/face-detection/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/ingest-croissant/build.sh
+++ b/apps/ingest-croissant/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/jupyterlab/build.sh
+++ b/apps/jupyterlab/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/mcp-server/build.sh
+++ b/apps/mcp-server/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/object-detection/build.sh
+++ b/apps/object-detection/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/rag/build.sh
+++ b/apps/rag/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/text-embeddings/build.sh
+++ b/apps/text-embeddings/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .

--- a/apps/text-extraction/build.sh
+++ b/apps/text-extraction/build.sh
@@ -3,12 +3,46 @@
 set -e # exit on error
 
 # Get the directory this script is in
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 # Extract the name of the directory
-NAME=$(basename ${DIR})
+NAME=$(basename "${DIR}")
 # Build an image name from the directory name
 IMAGE_NAME="aperturedata/workflows-${NAME}"
 
+
+TOP=$(git rev-parse --show-toplevel)
+
+# Check for uncommitted changes
+IS_DIRTY=$(git -C "$TOP" status --porcelain)
+if [ -n "$IS_DIRTY" ]; then
+  SHA_SUFFIX="+dirty"
+  DESCRIPTION_SUFFIX=" (with uncommitted changes)"
+else
+  SHA_SUFFIX=""
+  DESCRIPTION_SUFFIX=""
+fi
+
+# CI should provide these variables, but we need defaults for local builds
+VERSION="${VERSION:-dev}"
+GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_PATH_REL=$(realpath --relative-to="$TOP" "$DIR")
+SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}"
+DOCKERFILE_URL="${SOURCE_URL}/${SOURCE_PATH_REL}/Dockerfile"
+DESCRIPTION="Built from ${DOCKERFILE_URL} on ${BUILD_DATE}, version ${VERSION}${DESCRIPTION_SUFFIX}"
+echo "Description: ${DESCRIPTION}"
+
+
 # Build the image
-cd $DIR
-docker build -t ${IMAGE_NAME} .
+cd "$DIR"
+docker build -t "${IMAGE_NAME}" \
+    --label "org.opencontainers.image.version=${VERSION}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA_FULL}" \
+    --label "org.opencontainers.image.created=${BUILD_DATE}" \
+    --label "org.opencontainers.image.description=${DESCRIPTION}" \
+    --label "org.opencontainers.image.source=${SOURCE_URL}" \
+    --label "org.opencontainers.image.ref.name=docker.io/${IMAGE_NAME}:${VERSION}" \
+    .


### PR DESCRIPTION
Based on a meeting with @gsaluja9 and @drewaogle, this change:
* Provides a cleaner way to update the version number
* Adds the version number and other useful details to docker image labels
* Reports the version number in PR/commit comments
