### PR TITLE
Update version immediately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,14 @@ jobs:
           
           if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
             VERSION=$(scripts/increment_version.sh "${{ vars.VERSION }}")
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Increment version number now, even if tests fail, to avoid race conditions
+            curl --silent --show-error --fail --location --request PATCH \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/variables/VERSION \
+              -d "{\"value\":\"${VERSION}\"}"
+            elif [ "${{ github.event_name }}" == "pull_request" ]; then
             SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
             VERSION="pr-${{ github.event.number }}-${SHORT_SHA}"
           elif [ "${{ github.event_name }}" == "schedule" ]; then
@@ -187,19 +194,6 @@ jobs:
       VERSION: ${{ needs.get-version.outputs.version }}
 
     steps:
-      - name: Write updated version to Github variable
-        run: |
-          if [ -z "$VERSION" ]; then
-            echo "Missing version for update."
-            exit 1
-          fi
-          curl --silent --show-error --fail --location --request PATCH \
-            --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/variables/VERSION \
-            -d "{\"value\":\"${VERSION}\"}"
-
       - name: Comment on commit with version
         env:
           SHA: ${{ github.sha }}


### PR DESCRIPTION
We had a race condition recently, because we had two PRs merged close in time, and their CIs ran in parallel.
This approach potentially wastes integers by incrementing before the build and test.