### PR TITLE
suppress error in descriptor set creation

### DIFF
--- a/apps/text-embeddings/app/aperturedb_io.py
+++ b/apps/text-embeddings/app/aperturedb_io.py
@@ -193,7 +193,7 @@ class AperturedbIO:
                 f"Descriptor set {self.descriptorset_name} already exists")
             e = response[1]["FindDescriptorSet"]["entities"][0]
             if e["model"] != self.embedder.model_spec:
-                raise ValueError(
+                logger.error(
                     f"Descriptor set {self.descriptorset_name} already exists with different model {e['model']}, wanted to set {self.embedder.model_spec}")
             fingerprint_hash = self.embedder.fingerprint_hash()
             if e["model_fingerprint"] != fingerprint_hash:


### PR DESCRIPTION
There's a persistent race condition that seems to be much worse in cloud than on local dev, where two parts o the code race to create a descriptor set. If the wrong one wins, the other complains about the way it is set up. We need a better fix, but this will get things unstuck for today.