### PR TITLE
Fix for "Error creating dataset: 'ConnectionPool' object has no attribute 'clone'" in object detection workflow

### DIFF
--- a/apps/object-detection/app/eval.py
+++ b/apps/object-detection/app/eval.py
@@ -177,8 +177,9 @@ def main(params):
 
     print(f"Creating dataset...")
     try:
-        dataset = PyTorchDataset.ApertureDBDataset(
-            pool, q, batch_size=1, label_prop="_uniqueid")
+        with pool.get_connection() as client:
+            dataset = PyTorchDataset.ApertureDBDataset(
+                client, q, batch_size=1, label_prop="_uniqueid")
     except Exception as e:
         print("Error creating dataset:", e)
         dataset = []


### PR DESCRIPTION
use pool.get_connection() instead of pool