### PR TITLE
Exclude system connection classes from connection schema

### DIFF
--- a/apps/sql-server/fdw/fdw/connection.py
+++ b/apps/sql-server/fdw/fdw/connection.py
@@ -29,6 +29,11 @@ def connection_schema() -> List[TableDefinition]:
         assert isinstance(schema["connections"]["classes"], dict), \
             f"Expected connections.classes to be a dict, got {type(schema['connections']['classes'])}"
         for connection, data in schema["connections"]["classes"].items():
+            # We don't currently allow `with_class` to be used with internal connection classes.
+            if connection[0] == "_":
+                logger.warning(
+                    f"Skipping connection {connection} as it starts with an underscore")
+                continue
             results.append(connection_table(connection, data))
     return results
 


### PR DESCRIPTION
https://aperturedata.slack.com/archives/C02JVQP1WAK/p1754355921956819

As discussed, we do not permit `FindConnection`/`with_class` to be used with system connection classes.