### PR TITLE
Use TLS certs if available

### DIFF
--- a/apps/sql-server/app/app.sh
+++ b/apps/sql-server/app/app.sh
@@ -24,6 +24,18 @@ if [ -z "$WF_AUTH_TOKEN" ]; then
   exit 1
 fi
 
+# Make Postgres use the provided certificates if they exist
+if [ -f /etc/tls/certs/tls.crt ] && [ -f /etc/tls/certs/tls.key ]; then
+  echo "Using provided TLS certificates for PostgreSQL."
+  cat <<EOF >/etc/postgresql/${POSTGRES_VERSION}/main/postgresql.conf
+ssl = on
+ssl_cert_file = '/etc/tls/certs/tls.crt'
+ssl_key_file = '/etc/tls/certs/tls.key'
+EOF
+else
+  echo "Warning: TLS certificates not found at /etc/tls/certs/tls.crt and /etc/tls/certs/tls.key. PostgreSQL will not use SSL or will fall back to self-signed mode."
+fi
+
 # Start PostgreSQL in the background
 echo "Starting PostgreSQL..."
 /etc/init.d/postgresql start

--- a/apps/sql-server/app/app.sh
+++ b/apps/sql-server/app/app.sh
@@ -27,10 +27,18 @@ fi
 # Make Postgres use the provided certificates if they exist
 if [ -f /etc/tls/certs/tls.crt ] && [ -f /etc/tls/certs/tls.key ]; then
   echo "Using provided TLS certificates for PostgreSQL."
-  cat <<EOF >/etc/postgresql/${POSTGRES_VERSION}/main/postgresql.conf
+  # We copy the certificates because PostgreSQL is very particular about file permissions
+  mkdir -p /app/certs
+  cp /etc/tls/certs/tls.crt /app/certs/tls.crt
+  cp /etc/tls/certs/tls.key /app/certs/tls.key
+  chmod 600 /app/certs/tls.key
+  chown postgres:postgres /app/certs/tls.key
+  chmod 600 /app/certs/tls.crt
+  chown postgres:postgres /app/certs/tls.crt
+  cat <<EOF >>/etc/postgresql/${POSTGRES_VERSION}/main/postgresql.conf
 ssl = on
-ssl_cert_file = '/etc/tls/certs/tls.crt'
-ssl_key_file = '/etc/tls/certs/tls.key'
+ssl_cert_file = '/app/certs/tls.crt'
+ssl_key_file = '/app/certs/tls.key'
 EOF
 else
   echo "Warning: TLS certificates not found at /etc/tls/certs/tls.crt and /etc/tls/certs/tls.key. PostgreSQL will not use SSL or will fall back to self-signed mode."


### PR DESCRIPTION
This change makes SQL server use provide TLS certificates if available.
These will not be available in local testing.

I verified this change by applying it manually in a shell on a dev cloud workflow and restarting postgres.

```
$ openssl s_client -connect workflow-test8-76fskh9x.farm0004.cloud.aperturedata.dev:5432 -starttls postgres
Connecting to 34.8.250.238
CONNECTED(00000003)
depth=2 C=US, O=Internet Security Research Group, CN=ISRG Root X1
verify return:1
depth=1 C=US, O=Let's Encrypt, CN=R10
verify return:1
depth=0 CN=*.farm0004.cloud.aperturedata.dev
verify return:1
---
Certificate chain
 0 s:CN=*.farm0004.cloud.aperturedata.dev
   i:C=US, O=Let's Encrypt, CN=R10
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 14 16:58:43 2025 GMT; NotAfter: Sep 12 16:58:42 2025 GMT
 1 s:C=US, O=Let's Encrypt, CN=R10
   i:C=US, O=Internet Security Research Group, CN=ISRG Root X1
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Mar 13 00:00:00 2024 GMT; NotAfter: Mar 12 23:59:59 2027 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
subject=CN=*.farm0004.cloud.aperturedata.dev
issuer=C=US, O=Let's Encrypt, CN=R10
---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: RSA-PSS
Server Temp Key: ECDH, prime256v1, 256 bits
---
SSL handshake has read 3334 bytes and written 847 bytes
Verification: OK
---
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
Server public key is 2048 bit
This TLS version forbids renegotiation.
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 0 (ok)
---
805B009CCD7F0000:error:0A000126:SSL routines::unexpected eof while reading:ssl/record/rec_layer_s3.c:687:
```