### PR TITLE
fix datetime bug

### DIFF
--- a/apps/sql-server/app/app.py
+++ b/apps/sql-server/app/app.py
@@ -86,7 +86,7 @@ async def sql_query(
                     elif attr.type.name in ("bytea",):  # catch blobs
                         encoded = base64.b64encode(val).decode("ascii")
                         result_row.append(encoded)
-                    elif attr.type.name == "timestamp":
+                    elif attr.type.name == "timestamptz":
                         result_row.append(val.isoformat())
                     else:
                         result_row.append(val)


### PR DESCRIPTION
This fixes a bug in the HTTP API whereby datetime fields were encoded by the Postgres client library in a way that was not JON serializable.