### PR TITLE
handle a lack of connections or entities

### DIFF
--- a/apps/sql-server/fdw/fdw/connection.py
+++ b/apps/sql-server/fdw/fdw/connection.py
@@ -25,16 +25,23 @@ def connection_schema() -> List[TableDefinition]:
     logger.info("Creating connection schema")
     results = []
     schema = get_schema()
-    if "connections" in schema and "classes" in schema["connections"]:
-        assert isinstance(schema["connections"]["classes"], dict), \
-            f"Expected connections.classes to be a dict, got {type(schema['connections']['classes'])}"
-        for connection, data in schema["connections"]["classes"].items():
-            # We don't currently allow `with_class` to be used with internal connection classes.
-            if connection[0] == "_":
-                logger.warning(
-                    f"Skipping connection {connection} as it starts with an underscore")
-                continue
-            results.append(connection_table(connection, data))
+    if schema.get("connections") is None:
+        logger.warning("No connections found in schema")
+        return results
+    classes = schema.get("connections", {}).get("classes", {})
+    if not classes:
+        logger.warning("No connection classes found in schema")
+        return results
+
+    assert classes, \
+        f"Expected connections.classes to be a dict, got {type(schema['connections']['classes'])}"
+    for connection, data in classes.items():
+        # We don't currently allow `with_class` to be used with internal connection classes.
+        if connection[0] == "_":
+            logger.warning(
+                f"Skipping connection {connection} as it starts with an underscore")
+            continue
+        results.append(connection_table(connection, data))
     return results
 
 

--- a/apps/sql-server/fdw/fdw/entity.py
+++ b/apps/sql-server/fdw/fdw/entity.py
@@ -22,12 +22,18 @@ def entity_schema() -> List[TableDefinition]:
     logger.info("Creating entity schema")
     results = []
     schema = get_schema()
-    if "entities" in schema and "classes" in schema["entities"]:
-        assert isinstance(schema["entities"]["classes"], dict), \
-            f"Expected entities.classes to be a dict, got {type(schema['entities']['classes'])}"
-        for entity, data in schema["entities"]["classes"].items():
-            if entity[0] != "_":
-                results.append(entity_table(entity, data))
+    if schema.get("entities") is None:
+        logger.warning("No entities found in schema")
+        return results
+    classes = schema.get("entities", {}).get("classes", {})
+    if not classes:
+        logger.warning("No entity classes found in schema")
+        return results
+    assert classes, \
+        f"Expected entities.classes to be a dict, got {type(schema['entities']['classes'])}"
+    for entity, data in classes.items():
+        if entity[0] != "_":
+            results.append(entity_table(entity, data))
     return results
 
 

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -164,9 +164,10 @@ def system_entity_table() -> TableDefinition:
     """
     table_name = "Entity"
 
+    schema = get_schema()
     count = sum(
-        data.get("matched", 0) for class_, data in get_schema().get("entities", {}).get("classes", {}).items() if class_[0] != "_"
-    )
+        data.get("matched", 0) for class_, data in schema.get("entities", {}).get("classes", {}).items() if class_[0] != "_"
+    ) if schema.get("entities") else 0
 
     options = TableOptions(
         table_name=f'system."{table_name}"',
@@ -201,9 +202,10 @@ def system_connection_table() -> TableDefinition:
     """
     table_name = "Connection"
 
+    schema = get_schema()
     count = sum(
-        data.get("matched", 0) for class_, data in get_schema().get("connections", {}).get("classes", {}).items()
-    )
+        data.get("matched", 0) for class_, data in schema.get("connections", {}).get("classes", {}).items()
+    ) if schema.get("connections", {}) else 0
 
     options = TableOptions(
         table_name=f'system."{table_name}"',
@@ -254,6 +256,10 @@ def get_consistent_properties(type_: Literal["entities", "connections"]) -> List
     """
     property_types = defaultdict(set)
     schema = get_schema()
+    if not schema.get(type_):
+        logger.warning(f"No {type_} found in schema")
+        return []
+
     if type_ in schema and "classes" in schema[type_]:
         for data in schema[type_]["classes"].values():
             if "properties" in data and data["properties"] is not None:


### PR DESCRIPTION
It seems unlikely that anyone will want to use SQL to query an empty database, but this change ensures that we do not crash if we schema lacks either entities or connections.