### PR TITLE
fix max documents in crawl

### DIFF
--- a/apps/crawl-website/app/crawl_website.py
+++ b/apps/crawl-website/app/crawl_website.py
@@ -1,7 +1,7 @@
 from wf_argparse import ArgumentParser
 import os
 import logging
-from typing import List, Optional
+from typing import List, Optional, Generator
 from datetime import datetime, timezone
 from uuid import uuid4
 from urllib.parse import urlparse
@@ -101,7 +101,7 @@ class ApertureDBSpider(CrawlSpider):
                                 signal=signals.spider_closed)
         return spider
 
-    def process_response(self, response) -> ApertureDBItem:
+    def process_response(self, response) -> Generator[ApertureDBItem, None, None]:
         """Process the response from the request.
 
         The resulting item contains a properties dictionary and a blob.
@@ -114,7 +114,7 @@ class ApertureDBSpider(CrawlSpider):
             referrer = response.request.headers.get(
                 'Referer', b'None').decode('utf-8')
             self.error_urls.append([response.status, response.url, referrer])
-            return None
+            return
 
         properties = {}
 
@@ -167,7 +167,7 @@ class ApertureDBSpider(CrawlSpider):
         properties['crawl_time'] = {
             "_date": datetime.now(timezone.utc).isoformat()}
 
-        return ApertureDBItem(properties=properties, blob=response.body)
+        yield ApertureDBItem(properties=properties, blob=response.body)
 
     def spider_closed(self, reason):
         logging.info(f"Spider closed: {reason}")

--- a/apps/rag/test.sh
+++ b/apps/rag/test.sh
@@ -79,7 +79,7 @@ function run_crawl() {
                --network ${NETWORK_NAME} \
                -e DB_HOST=${APERTUREDB_NAME} \
                -e WF_START_URLS=${CRAWL_URL} \
-               -e WF_MAX_DOCUMENTS=100 \
+               -e WF_MAX_DOCUMENTS=20 \
                -e WF_OUTPUT=${ID} \
                --rm \
                ${CRAWL_IMAGE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
             WF_CLEAN: "${WF_CLEAN:-true}"
             WF_START_URLS: "${WF_START_URLS:-https://docs.aperturedata.io/}"
             WF_LOG_LEVEL: "${WF_LOG_LEVEL:-DEBUG}"
+            WF_MAX_DOCUMENTS: "${WF_MAX_DOCUMENTS:-20}"
 
     dataset-ingestion:
         build: 
@@ -200,3 +201,5 @@ services:
             WF_CLEAN: "${WF_CLEAN:-true}"
             WF_START_URLS: "${WF_START_URLS:-https://docs.aperturedata.io/}"
             WF_LOG_LEVEL: "${WF_LOG_LEVEL:-DEBUG}"
+            WF_MAX_DOCUMENTS: "${WF_MAX_DOCUMENTS:-20}"
+


### PR DESCRIPTION
This fixes a long-standing problem that `--max-documents` was not being respected by the crawl-website workflow, which made tests unnecessarily slow.