### PR TITLE
pin cv2

### DIFF
--- a/apps/jupyterlab/requirements.txt
+++ b/apps/jupyterlab/requirements.txt
@@ -1,2 +1,4 @@
 fastmcp==2.10.2
 psycopg[binary]
+numpy<2
+opencv-python-headless==4.11.0.86


### PR DESCRIPTION
I discovered today that our Jupyterlab workflow can no longer import cv2:

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.2.6 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
```

This appears to be related to the upgrade of opencv-python-headless from 4.11.0.86 to 4.12.0.88, and the associated change in numpy version dependency. 

As a temporary measure, I am fixing this by pinning opencv-python-headless, but we should investigate further and push the fix upstream into the notebook image.