### PR TITLE
detect zero documents earlier, kill process group better

### DIFF
--- a/apps/crawl-to-rag/Dockerfile
+++ b/apps/crawl-to-rag/Dockerfile
@@ -1,9 +1,9 @@
 # Name the source images
 ARG VERSION=latest
-FROM aperturedata/workflows-crawl-website:${VERSION} as crawl-website
-FROM aperturedata/workflows-text-extraction:${VERSION} as text-extraction
-FROM aperturedata/workflows-text-embeddings:${VERSION} as text-embeddings
-FROM aperturedata/workflows-rag:${VERSION} as rag
+FROM aperturedata/workflows-crawl-website:${VERSION} AS crawl-website
+FROM aperturedata/workflows-text-extraction:${VERSION} AS text-extraction
+FROM aperturedata/workflows-text-embeddings:${VERSION} AS text-embeddings
+FROM aperturedata/workflows-rag:${VERSION} AS rag
 
 FROM aperturedata/workflows-base:${VERSION}
 

--- a/apps/crawl-to-rag/app.sh
+++ b/apps/crawl-to-rag/app.sh
@@ -114,9 +114,11 @@ echo "Pipeline completed with status $pipeline_status"
 
 if [ $pipeline_status -ne 0 ]; then
     echo "Pipeline failed with status $pipeline_status, shutting down server"
-    kill $server_pid 2>/dev/null || true
-    pkill -f 'uvicorn' || true
-    wait $server_pid 2>/dev/null || true
+    pgid="$(ps -o pgid= -p $$ | tr -d ' ')"
+    echo "Killing server with PGID $pgid"
+    kill -TERM "-$pgid" || true
+    sleep 1 # Give server time to shut down gracefully
+    kill -KILL "-$pgid" || true
     exit $pipeline_status
 fi
 

--- a/apps/crawl-website/app/crawl_website.py
+++ b/apps/crawl-website/app/crawl_website.py
@@ -184,6 +184,11 @@ class ApertureDBSpider(CrawlSpider):
 
         doc_count = self.crawler.stats.get_value('itempipeline/item_count', 0)
         logging.info(f"Total documents processed: {doc_count}")
+        if doc_count == 0:
+            logging.error(
+                "No documents processed, this may indicate an issue with the crawl.")
+            self.crawler.engine.close_spider(self, "no_documents_processed")
+            os._exit(1)
 
 
 class ApertureDBPipeline:

--- a/apps/crawl-website/app/crawl_website.py
+++ b/apps/crawl-website/app/crawl_website.py
@@ -188,6 +188,7 @@ class ApertureDBSpider(CrawlSpider):
             logging.error(
                 "No documents processed, this may indicate an issue with the crawl.")
             self.crawler.engine.close_spider(self, "no_documents_processed")
+            # Bypass scrapy's error handling to exit immediately
             os._exit(1)
 
 

--- a/apps/jupyterlab/requirements.txt
+++ b/apps/jupyterlab/requirements.txt
@@ -1,2 +1,4 @@
 fastmcp==2.10.2
 psycopg[binary]
+numpy<2
+opencv-python-headless==4.11.0.86


### PR DESCRIPTION
As discussed, this does a better job of killing off child processes when an error is detected in the pipeline.
I also included a change to detect the "zero document" case earlier and with a clearer error message.
@gsaluja9 I suspect you will want to insert a status server update call here.