### PR TITLE
Raise when an exception occurs in object-detection workflow

### DIFF
--- a/apps/object-detection/app/eval.py
+++ b/apps/object-detection/app/eval.py
@@ -149,7 +149,7 @@ def main(params):
         except:
             print("Error getting total images:")
             db.print_last_response()
-            total = 0
+            raise
 
     if total == 0:
         print("No images to process.")
@@ -182,7 +182,7 @@ def main(params):
                 client, q, batch_size=1, label_prop="_uniqueid")
     except Exception as e:
         print("Error creating dataset:", e)
-        dataset = []
+        raise
 
     total = len(dataset)
     print("Total images in the dataset:", total)

--- a/apps/object-detection/app/eval.py
+++ b/apps/object-detection/app/eval.py
@@ -305,10 +305,11 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         print("Something went wrong, exiting...")
+        raise
     except KeyboardInterrupt:
         stop = True
         print("Keyboard interrupt, exiting...")
-
-    dist.destroy_process_group()
+    finally:
+        dist.destroy_process_group()
 
     print("Done, bye.")


### PR DESCRIPTION
In the object-detection workflow, exceptions are currently printed but not raised. As a result, underlying issues can go unnoticed.
This PR updates the workflow to raise exceptions when they occur, ensuring that failures can be addressed promptly. 