### PR TITLE
make sql-server bullet-proof for empty database

### DIFF
--- a/apps/sql-server/fdw/fdw/common.py
+++ b/apps/sql-server/fdw/fdw/common.py
@@ -2,7 +2,7 @@ from typing import Callable, Any
 from pydoc import locate
 from pydantic import BaseModel, GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from collections import defaultdict
-from typing import List, Optional, Dict, Callable, Any
+from typing import List, Optional, Dict, Callable, Any, Literal
 from multicorn import ColumnDefinition
 from dotenv import load_dotenv
 import logging
@@ -74,6 +74,27 @@ def get_schema() -> Dict:
             _SCHEMA = utils.get_schema()
             logger.info("Schema loaded")
     return _SCHEMA
+
+
+def get_classes(field: Literal["entities", "connections"],
+                schema: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """
+    Get the classes for entities or connections from the schema.
+
+    Guarantees to return a (possibly empty) dict, even if the field is not present.
+    """
+    if schema is None:
+        schema = get_schema()
+    if schema.get(field) is None:
+        logger.warning(f"No {field} found in schema")
+        return {}
+    classes = schema.get(field, {}).get("classes", {})
+    if not classes:
+        logger.warning(f"No {field} classes found in schema")
+        return {}
+    assert classes, \
+        f"Expected {field}.classes to be a dict, got {type(schema[field]['classes'])}"
+    return classes
 
 
 # Mapping from ApertureDB types to PostgreSQL types.

--- a/apps/sql-server/fdw/fdw/common.py
+++ b/apps/sql-server/fdw/fdw/common.py
@@ -92,8 +92,6 @@ def get_classes(field: Literal["entities", "connections"],
     if not classes:
         logger.warning(f"No {field} classes found in schema")
         return {}
-    assert classes, \
-        f"Expected {field}.classes to be a dict, got {type(schema[field]['classes'])}"
     return classes
 
 

--- a/apps/sql-server/fdw/fdw/connection.py
+++ b/apps/sql-server/fdw/fdw/connection.py
@@ -8,7 +8,7 @@
 
 import logging
 from typing import List
-from .common import get_schema, Curry
+from .common import get_classes, Curry
 from .column import property_columns, ColumnOptions
 from .table import TableOptions, literal
 from multicorn import TableDefinition, ColumnDefinition
@@ -24,17 +24,7 @@ def connection_schema() -> List[TableDefinition]:
     """
     logger.info("Creating connection schema")
     results = []
-    schema = get_schema()
-    if schema.get("connections") is None:
-        logger.warning("No connections found in schema")
-        return results
-    classes = schema.get("connections", {}).get("classes", {})
-    if not classes:
-        logger.warning("No connection classes found in schema")
-        return results
-
-    assert classes, \
-        f"Expected connections.classes to be a dict, got {type(schema['connections']['classes'])}"
+    classes = get_classes("connections")
     for connection, data in classes.items():
         # We don't currently allow `with_class` to be used with internal connection classes.
         if connection[0] == "_":

--- a/apps/sql-server/fdw/fdw/descriptor.py
+++ b/apps/sql-server/fdw/fdw/descriptor.py
@@ -9,7 +9,7 @@
 
 from multicorn import TableDefinition, ColumnDefinition
 from typing import List
-from .common import get_schema, get_pool, import_from_app, Curry
+from .common import get_classes, get_pool, import_from_app, Curry
 from .column import property_columns, ColumnOptions, blob_columns
 from .table import TableOptions, literal
 import logging
@@ -132,8 +132,8 @@ def property_columns_for_descriptors_in_set(name: str) -> List[ColumnDefinition]
 
     _, response, _ = get_pool().execute_query(query)
 
-    properties = response[1]["GetSchema"].get(
-        "entities", {}).get("classes", {}).get("_Descriptor", {})
+    classes = get_classes("entities", response[1]["GetSchema"])
+    properties = classes.get("_Descriptor", {})
 
     columns = property_columns(properties)
 

--- a/apps/sql-server/fdw/fdw/entity.py
+++ b/apps/sql-server/fdw/fdw/entity.py
@@ -5,7 +5,7 @@
 # SELECT * FROM "CrawlDocument" LIMIT 10;
 
 from multicorn import TableDefinition
-from .common import get_schema, Curry
+from .common import get_classes, Curry
 from .column import property_columns
 from .table import TableOptions, literal
 from typing import List
@@ -21,16 +21,7 @@ def entity_schema() -> List[TableDefinition]:
     """
     logger.info("Creating entity schema")
     results = []
-    schema = get_schema()
-    if schema.get("entities") is None:
-        logger.warning("No entities found in schema")
-        return results
-    classes = schema.get("entities", {}).get("classes", {})
-    if not classes:
-        logger.warning("No entity classes found in schema")
-        return results
-    assert classes, \
-        f"Expected entities.classes to be a dict, got {type(schema['entities']['classes'])}"
+    classes = get_classes("entities")
     for entity, data in classes.items():
         if entity[0] != "_":
             results.append(entity_table(entity, data))


### PR DESCRIPTION
https://github.com/aperture-data/workflows/pull/131 covered many cases, but apparently missed one. This factors out the relevant code so that all paths are consistently using the same way to extract classes from the schema.