### PR TITLE
Enhanced constraints and query planner hooks

### DIFF
--- a/apps/sql-server/README.md
+++ b/apps/sql-server/README.md
@@ -38,7 +38,7 @@ This workflow provides four different types of table, added to four different sc
 
 * **`system`**: Table for every system object type used in the database, e.g. `Descriptor`, `DescriptorSet`, `Image`, `BoundingBox`. In particular, there are tables for `Entity` and `Connection`, which will have any properties that are consistently-typed across all classes.
 * **`entity`**: Table for every user-defined entity class, e.g. `CrawlDocument`.
-* **`connection`**: Table for every user-defined connection class, e.g. `crawlDocumentHasBlob`. Note that in addition to the usual `_uniqueid`, connections also have columns for `_src` and `_dst`.
+* **`connection`**: Table for every connection class, e.g. `crawlDocumentHasBlob`. Note that in addition to the usual `_uniqueid`, connections also have columns for `_src` and `_dst`.
 * **`descriptor`**: Table for every descriptor set.
 
 > **Note**: Tables are published at startup, based on the ApertureDB schema at the time. If classes or properties are added later, they will not be available through this interface until the workflow is restarted. 

--- a/apps/sql-server/fdw/fdw/__init__.py
+++ b/apps/sql-server/fdw/fdw/__init__.py
@@ -418,14 +418,14 @@ class FDW(ForeignDataWrapper):
                            get_result_objects: Optional[Callable],
                            ) -> Generator[Tuple[dict, Optional[bytes]], None, List[dict]]:
         start_time = datetime.now()
-        _, results, response_blobs = execute_query(query, query_blobs)
+        status, results, response_blobs = execute_query(query, query_blobs)
         elapsed_time = datetime.now() - start_time
 
-        if not results or len(results) != len(query):
+        if not results or len(results) != len(query) or not isinstance(results, list) or status != 0:
             logger.warning(
-                f"No results found for entity query. {query} -> {results}")
+                f"No results found for entity query. {query} -> {status} {results}")
             raise ValueError(
-                f"No results found for entity query: {query}. Please check the class and columns. Results: {results}")
+                f"No results found for entity query: {query}. Please check the class and columns. Results: {status} {results}")
 
         if get_result_objects:
             # If a special function is provided, apply it to the results.

--- a/apps/sql-server/fdw/fdw/__init__.py
+++ b/apps/sql-server/fdw/fdw/__init__.py
@@ -579,7 +579,7 @@ class FDW(ForeignDataWrapper):
         logger.info(
             f"Estimating relation size for FDW {self._options.table_name} with quals: {quals} and columns: {columns}")
         query = self._get_query(quals, columns)[0]
-        command_body = query[-1][self._options.command]
+        command_body = get_command_body(query[-1])
         blobs = command_body.get("blobs", False)
 
         n_rows = self._options.count

--- a/apps/sql-server/fdw/fdw/aperturedb.py
+++ b/apps/sql-server/fdw/fdw/aperturedb.py
@@ -11,6 +11,7 @@ import base64
 import uuid
 from typing import List, Optional, Tuple
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ def execute_query(
     blobs: Optional[List[bytes]] = None,
     uds_path: str = "/tmp/aperturedb-proxy.sock",
 ) -> Tuple[int, List[dict], Optional[List[bytes]]]:
+    start_time = datetime.now()
     logger.debug(
         f"Executing query: {json_query} with blobs: {len(blobs) if blobs else 0}")
     boundary = "----apdb-" + uuid.uuid4().hex
@@ -81,6 +83,7 @@ def execute_query(
     out_json = parsed["json"]
     out_blobs = [base64.b64decode(s) for s in parsed.get("blobs", [])] or None
     out_status = parsed.get('status', 0)
+    elapsed_time = datetime.now() - start_time
     logger.debug(
-        f"Query executed successfully, status: {out_status}, json: {out_json}, blobs: {len(out_blobs) if out_blobs else 0}")
+        f"Query executed successfully in {elapsed_time.total_seconds()} seconds, status: {out_status}, json: {json.dumps(out_json)[:200]}{'...' if len(json.dumps(out_json))  > 200 else ''}, blobs: {len(out_blobs) if out_blobs else 0}")
     return out_status, out_json, out_blobs

--- a/apps/sql-server/fdw/fdw/column.py
+++ b/apps/sql-server/fdw/fdw/column.py
@@ -74,7 +74,7 @@ class ColumnOptions(BaseModel):
         This is used to extract the path keys from the column definition.
         """
         if self.indexed or self.type == "uniqueid":
-            expected_rows = 1 if name == "_uniqueid" else 1000
+            expected_rows = 1 if name == "_uniqueid" else 1000  # See FDW.get_path_keys
             yield ([name], expected_rows)
             if name == "_src":
                 yield (["_src", "_dst"], 1)

--- a/apps/sql-server/fdw/fdw/column.py
+++ b/apps/sql-server/fdw/fdw/column.py
@@ -1,7 +1,7 @@
 from .common import Curry, TYPE_MAP
 import logging
 from pydantic import BaseModel
-from typing import List, Dict, Any, Optional, Literal
+from typing import List, Dict, Any, Optional, Literal, Tuple, Generator
 from multicorn import ColumnDefinition
 import json
 
@@ -67,6 +67,19 @@ class ColumnOptions(BaseModel):
         This is used to encode options for the foreign table column definition.
         """
         return {"column_options": json.dumps(self.dict(), default=str)}
+
+    def path_keys(self, name: str) -> Generator[Tuple[List[str], int], None, None]:
+        """
+        Return the path keys for this column.
+        This is used to extract the path keys from the column definition.
+        """
+        if self.indexed or self.type == "uniqueid":
+            expected_rows = 1 if name == "_uniqueid" else 10
+            yield ([name], expected_rows)
+            if name == "_src":
+                yield (["_src", "_dst"], 1)
+            elif name == "_dst":
+                yield (["_dst", "_src"], 1)
 
     # Reject any extra fields that are not defined in the model.
     model_config = {
@@ -181,3 +194,14 @@ def uniqueid_column(count: int = 0) -> ColumnDefinition:
             unique=True,
             type="uniqueid"
         ).to_string())
+
+
+def get_path_keys(columns: List[ColumnDefinition]) -> List[Tuple[List[str], int]]:
+    """
+    Extract the path keys from the column definitions.
+    """
+    path_keys = []
+    for col in columns:
+        options = ColumnOptions.from_string(col.options)
+        path_keys.extend(options.path_keys(col.column_name))
+    return path_keys

--- a/apps/sql-server/fdw/fdw/column.py
+++ b/apps/sql-server/fdw/fdw/column.py
@@ -74,7 +74,7 @@ class ColumnOptions(BaseModel):
         This is used to extract the path keys from the column definition.
         """
         if self.indexed or self.type == "uniqueid":
-            expected_rows = 1 if name == "_uniqueid" else 10
+            expected_rows = 1 if name == "_uniqueid" else 1000
             yield ([name], expected_rows)
             if name == "_src":
                 yield (["_src", "_dst"], 1)

--- a/apps/sql-server/fdw/fdw/common.py
+++ b/apps/sql-server/fdw/fdw/common.py
@@ -230,3 +230,11 @@ def compact_pretty_json(data: Any, line_length=78, level=0, indent=2) -> str:
 
     else:
         return prefix + json.dumps(data, ensure_ascii=False)
+
+
+def get_command_body(command: dict) -> dict:
+    """
+    Extract the command body from a command dictionary.
+    This is used to get the command body for modify_query hooks.
+    """
+    return next(iter(command.values()))

--- a/apps/sql-server/fdw/fdw/common.py
+++ b/apps/sql-server/fdw/fdw/common.py
@@ -170,7 +170,6 @@ class Curry:
 
     @classmethod
     def _validate(cls, value: Any) -> "Curry":
-        logger.debug(f"Validating Curry: {value}")
         if isinstance(value, cls):
             return value
         elif isinstance(value, dict):

--- a/apps/sql-server/fdw/fdw/connection.py
+++ b/apps/sql-server/fdw/fdw/connection.py
@@ -9,7 +9,7 @@
 import logging
 from typing import List
 from .common import get_classes, Curry
-from .column import property_columns, ColumnOptions
+from .column import property_columns, ColumnOptions, get_path_keys
 from .table import TableOptions, literal
 from multicorn import TableDefinition, ColumnDefinition
 
@@ -43,14 +43,6 @@ def connection_table(connection: str, data: dict) -> TableDefinition:
 
     table_name = connection
 
-    options = TableOptions(
-        table_name=f'connection."{table_name}"',
-        count=data.get("matched", 0),
-        command="FindConnection",
-        result_field="connections",
-        modify_command_body=Curry(literal, {"with_class": connection}),
-    )
-
     columns = []
 
     try:
@@ -77,6 +69,17 @@ def connection_table(connection: str, data: dict) -> TableDefinition:
         logger.exception(
             f"Error processing properties for connection {connection}: {e}")
         raise
+
+    path_keys = get_path_keys(columns)
+
+    options = TableOptions(
+        table_name=f'connection."{table_name}"',
+        count=data.get("matched", 0),
+        command="FindConnection",
+        result_field="connections",
+        modify_command_body=Curry(literal, {"with_class": connection}),
+        path_keys=path_keys,
+    )
 
     logger.debug(
         f"Creating connection table for {connection} with columns: {columns} and options: {options}")

--- a/apps/sql-server/fdw/fdw/connection.py
+++ b/apps/sql-server/fdw/fdw/connection.py
@@ -10,7 +10,7 @@ import logging
 from typing import List
 from .common import get_classes, Curry
 from .column import property_columns, ColumnOptions, get_path_keys
-from .table import TableOptions, literal
+from .table import TableOptions, literal, connection as table_connection
 from multicorn import TableDefinition, ColumnDefinition
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ def connection_table(connection: str, data: dict) -> TableDefinition:
         count=data.get("matched", 0),
         command="FindConnection",
         result_field="connections",
-        modify_query=Curry(connection, class_name=connection,
+        modify_query=Curry(table_connection, class_name=connection,
                            src_class=data["src"], dst_class=data["dst"]),
         path_keys=path_keys,
     )

--- a/apps/sql-server/fdw/fdw/connection.py
+++ b/apps/sql-server/fdw/fdw/connection.py
@@ -10,7 +10,7 @@ import logging
 from typing import List
 from .common import get_classes, Curry
 from .column import property_columns, ColumnOptions, get_path_keys
-from .table import TableOptions, literal, connection as table_connection
+from .table import TableOptions, connection as table_connection
 from multicorn import TableDefinition, ColumnDefinition
 
 logger = logging.getLogger(__name__)

--- a/apps/sql-server/fdw/fdw/descriptor.py
+++ b/apps/sql-server/fdw/fdw/descriptor.py
@@ -84,7 +84,7 @@ def descriptor_schema() -> List[TableDefinition]:
             count=properties["_count"],
             command="FindDescriptor",
             result_field="entities",
-            modify_command_body=Curry(
+            modify_query=Curry(
                 literal, {"set": name, "distances": True}),
             path_keys=path_keys,
         )

--- a/apps/sql-server/fdw/fdw/entity.py
+++ b/apps/sql-server/fdw/fdw/entity.py
@@ -55,7 +55,7 @@ def entity_table(entity: str, data: dict) -> TableDefinition:
         count=data.get("matched", 0),
         command="FindEntity",
         result_field="entities",
-        modify_command_body=Curry(literal, {"with_class": entity}),
+        modify_query=Curry(literal, {"with_class": entity}),
         path_keys=path_keys,
     )
 

--- a/apps/sql-server/fdw/fdw/entity.py
+++ b/apps/sql-server/fdw/fdw/entity.py
@@ -6,7 +6,7 @@
 
 from multicorn import TableDefinition
 from .common import get_classes, Curry
-from .column import property_columns
+from .column import property_columns, get_path_keys
 from .table import TableOptions, literal
 from typing import List
 import logging
@@ -39,14 +39,6 @@ def entity_table(entity: str, data: dict) -> TableDefinition:
 
     table_name = entity
 
-    options = TableOptions(
-        table_name=f'entity."{table_name}"',
-        count=data.get("matched", 0),
-        command="FindEntity",
-        result_field="entities",
-        modify_command_body=Curry(literal, {"with_class": entity}),
-    )
-
     columns = []
 
     try:
@@ -55,6 +47,17 @@ def entity_table(entity: str, data: dict) -> TableDefinition:
         logger.exception(
             f"Error processing properties for entity {entity}: {e}")
         raise
+
+    path_keys = get_path_keys(columns)
+
+    options = TableOptions(
+        table_name=f'entity."{table_name}"',
+        count=data.get("matched", 0),
+        command="FindEntity",
+        result_field="entities",
+        modify_command_body=Curry(literal, {"with_class": entity}),
+        path_keys=path_keys,
+    )
 
     logger.debug(
         f"Creating entity table for {entity} as {table_name} with columns: {columns} and options: {options}")

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -8,7 +8,7 @@
 from typing import List, Literal, Set, Any, Dict
 from .common import get_classes, TYPE_MAP, Curry
 from .column import property_columns, ColumnOptions, blob_columns, uniqueid_column, passthrough, get_path_keys
-from .table import TableOptions, literal, connection as table_connection
+from .table import TableOptions, connection as table_connection
 from multicorn import TableDefinition, ColumnDefinition
 import logging
 from collections import defaultdict

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -282,6 +282,6 @@ def get_consistent_properties(type_: Literal["entities", "connections"]) -> List
                 logger.warning(
                     f"Unknown type '{prop_type}' for property '{prop}' in system {type_} table.")
         else:
-            logger.warning(
+            logger.debug(
                 f"Property '{prop}' has multiple types: {types}. Skipping.")
     return columns

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -234,6 +234,10 @@ def system_connection_table() -> TableDefinition:
         command="FindConnection",
         result_field="connections",
         path_keys=path_keys,
+        modify_query=Curry(connection,
+                           class_name=None,  # No specific class name for system connections
+                           src_class=None,
+                           dst_class=None,)
     )
 
     logger.debug(
@@ -257,8 +261,8 @@ def get_consistent_properties(type_: Literal["entities", "connections"]) -> List
     classes = get_classes(type_)
     for data in classes.values():
         if "properties" in data and data["properties"] is not None:
-            assert isinstance(data["properties"], dict), \
-                f"Expected properties to be a dict, got {type(data['properties'])}"
+            assert isinstance(data["properties"], dict),
+            f"Expected properties to be a dict, got {type(data['properties'])}"
             for prop, prop_data in data["properties"].items():
                 count, indexed, prop_type = prop_data
                 property_types[prop].add(prop_type.lower())

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -8,7 +8,7 @@
 from typing import List, Literal, Set, Any, Dict
 from .common import get_classes, TYPE_MAP, Curry
 from .column import property_columns, ColumnOptions, blob_columns, uniqueid_column, passthrough, get_path_keys
-from .table import TableOptions, literal
+from .table import TableOptions, literal, connection as table_connection
 from multicorn import TableDefinition, ColumnDefinition
 import logging
 from collections import defaultdict
@@ -234,7 +234,7 @@ def system_connection_table() -> TableDefinition:
         command="FindConnection",
         result_field="connections",
         path_keys=path_keys,
-        modify_query=Curry(connection,
+        modify_query=Curry(table_connection,
                            class_name=None,  # No specific class name for system connections
                            src_class=None,
                            dst_class=None,)
@@ -261,8 +261,8 @@ def get_consistent_properties(type_: Literal["entities", "connections"]) -> List
     classes = get_classes(type_)
     for data in classes.values():
         if "properties" in data and data["properties"] is not None:
-            assert isinstance(data["properties"], dict),
-            f"Expected properties to be a dict, got {type(data['properties'])}"
+            assert isinstance(data["properties"], dict), \
+                f"Expected properties to be a dict, got {type(data['properties'])}"
             for prop, prop_data in data["properties"].items():
                 count, indexed, prop_type = prop_data
                 property_types[prop].add(prop_type.lower())

--- a/apps/sql-server/fdw/fdw/table.py
+++ b/apps/sql-server/fdw/fdw/table.py
@@ -104,6 +104,8 @@ def connection(class_name: Optional[str],
     # Does it request or constrain _src or _dst?
     # Does it request or constrain any other connection properties?
     is_system_class = class_name and class_name.startswith("_")
+    assert "FindConnection" in query[0], \
+        "This hook should only be used with a FindConnection command"
     command_body = get_command_body(query[0])
     constraints = command_body.get("constraints", {})
     src_constraint = constraints.get("_src")

--- a/apps/sql-server/fdw/fdw/table.py
+++ b/apps/sql-server/fdw/fdw/table.py
@@ -193,6 +193,8 @@ def connection(class_name: Optional[str],
             Extracts the result objects from the response.
             This is used to rewrite the results for cases 5 and 6.
             """
+            assert isinstance(response, list) and len(response) == 2, \
+                f"Response should have exactly two elements for is_connected_to: {response}"
             d = get_command_body(response[-1])
             for k, v in d.items():
                 for x in v:

--- a/apps/sql-server/fdw/fdw/table.py
+++ b/apps/sql-server/fdw/fdw/table.py
@@ -1,7 +1,7 @@
 from .common import Curry
 import logging
 from pydantic import BaseModel
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -19,6 +19,8 @@ class TableOptions(BaseModel):
     command: str = "FindEntity"
     # field to look for in the response, e.g. "entities", "connections"
     result_field: str = "entities"
+    # path keys for the table; see https://github.com/pgsql-io/multicorn2/blob/7ab7f0bcfe6052ebb318ed982df8dfd78ce5ee6a/python/multicorn/__init__.py#L215
+    path_keys: List[Tuple[List[str], int]] = []
 
     # This hook is used to modify the command body before executing it.
     # It is passed the command body as `command_body`.

--- a/apps/sql-server/test/seed.py
+++ b/apps/sql-server/test/seed.py
@@ -27,6 +27,25 @@ def load_testdata(client):
                                         "n": n,
                                         "s": s
                                     })}})
+
+    ref = 1
+    for i in range(5):
+        query.append({"AddEntity": {"class": "SourceNode",
+                                    "properties": {"source_key": i},
+                                    "_ref": ref,
+                                    }})
+        query.append({"AddEntity": {"class": "DestinationNode",
+                                    "properties": {"destination_key": i},
+                                    "_ref": ref + 1,
+                                    }})
+        query.append({"AddConnection": {
+            "src": ref,
+            "dst": ref + 1,
+            "class": "edge",
+            "properties": {"edge_key": i},
+        }})
+        ref += 2
+
     execute_query(client, query)
 
 
@@ -43,8 +62,6 @@ if __name__ == "__main__":
     load_testdata(client)
     print("Test data loaded successfully.")
 
-    _, results, _ = execute_query(
-        client, [{"FindEntity": {"with_class": "TestRow",
-                                 "results": {"all_properties": True}}}]
-    )
+    _, results, _ = execute_query(client, [{"GetSchema": {}}])
+
     print("Loaded test data:", results)

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -290,6 +290,7 @@ def test_join_query(query, sql_connection, constraint_formatter):
     except Exception as e:
         print(
             f"Error executing query: {e} - {query} - {query_aql(query, sql_connection)}")
+        raise
 
     assert len(
         result) == 5, f"Expected 5 rows, got {len(result)} for query: {query}, {query_aql(query, sql_connection)}"

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -276,7 +276,9 @@ def multicorn_plan(plan_node: dict) -> str:
     "SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};",
     "SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids};",
     "SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _dst IN {dst_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};",
+    pytest.param("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};",
+                 marks=pytest.mark.xfail(
+                     reason="https://github.com/aperture-data/athena/issues/1737")),
 ])
 def test_join_query(query, sql_connection, constraint_formatter):
     """


### PR DESCRIPTION
This PR adds new methods `get_rel_size` and `get_path_keys` that are new methods intended to help the query planner choose the best order in which to scan tables and how best to pushdown constraints. It also fixes various bugs in constraints, and in particular adds the ability to constraint `_src` and `_dst` on connection tables, even though that is not supported directly by ApertureDB.

The result is not perfect. In particular, we do not advertize `_uniqueid`, `_src`, and `_dst` as indexed, which discourages pushdown constraints on them. This is because the query planner perceives this FDW has having zero per-query overhead, so asking for 100 rows one by one is estimated to have the same cost as asking for 100 rows in a single query. This is an odd default, as I don't believe it's true for any FDW. I believe this is fixable, but only by extending the underlying Multicorn library. (See `startupCost` in https://github.com/pgsql-io/multicorn2/blob/main/src/multicorn.c and consider adding optional fields to `TableDefinition`.)

Logging and testing are also much improved.