### PR TITLE
Skip status update if float parsing fails

### DIFF
--- a/base/docker/scripts/log_processor.py
+++ b/base/docker/scripts/log_processor.py
@@ -2,6 +2,7 @@ import time
 from typing import List
 import requests
 import os
+import re
 import sys
 
 import datetime
@@ -19,19 +20,21 @@ class LogProcessor:
         # Continuously read from stderr
         last_time = time.time()
         completed = 100.0
-        need_update = False
         for line in iter(self.process.stderr.readline, ''):
             msg = line.strip()
+            need_update = False
 
             if msg.startswith("Progress:"):
-                # Extract the progress percentage from the message
-                progress = msg.split(":")[1].strip()
-                completed = progress.split("%")[0].strip()
-                try:
-                    completed = float(completed)
+                match_percent = re.search(r"Progress:\s*(\d+(?:\.\d+)?)%", msg)
+                if match_percent:
+                    # handle normal format
+                    completed = float(match_percent.group(1))
                     need_update = True
-                except (ValueError, TypeError):
+                elif re.search(r"Progress:\s*\d+(?:\.\d+)?items\s*\[", msg):
+                    # zero-item format - ignore
                     pass
+                else:
+                    raise ValueError(f"Unexpected progress format: {msg}")
 
             # print("Progress:", line.strip(), flush=True)
             if need_update and time.time() - last_time >= 1:
@@ -43,7 +46,6 @@ class LogProcessor:
 
         # Wait for the process to complete
         self.process.wait()
-
 
 
 app = Typer()

--- a/base/docker/scripts/log_processor.py
+++ b/base/docker/scripts/log_processor.py
@@ -27,7 +27,11 @@ class LogProcessor:
                 # Extract the progress percentage from the message
                 progress = msg.split(":")[1].strip()
                 completed = progress.split("%")[0].strip()
-                need_update = True
+                try:
+                    completed = float(completed)
+                    need_update = True
+                except (ValueError, TypeError):
+                    pass
 
             # print("Progress:", line.strip(), flush=True)
             if need_update and time.time() - last_time >= 1:


### PR DESCRIPTION
Handled an edge case where tqdm progress messages differ when the total number of images is zero.
The previous logic failed to parse float values due to unexpected message formatting

Standard format (when total > 0)
[2025-08-21T18:56:53.167549] Progress:   0%|          | 0.00/100 [00:00<?, ?items/s]
[2025-08-21T18:56:57.058000] Progress:   1%|          | 1.00/100 [00:06<10:20, 6.26s/items]

Edge case format (when total == 0)
[2025-08-21T20:53:48.837656]Progress: 0.00items [00:00, ?items/s]


