### PR TITLE
fix merge problems (again)

### DIFF
--- a/apps/sql-server/test.sh
+++ b/apps/sql-server/test.sh
@@ -36,8 +36,8 @@ echo ">>> Running $WORKFLOW tests (project=$COMPOSE_PROJECT_NAME)"
 COMMAND="$COMPOSE_SCRIPT -v -p $COMPOSE_PROJECT_NAME \
   -f $COMPOSE_MAIN -f $COMPOSE_TEST"
 
-# Should the test script be building sql-server?
-$COMMAND build base test-base sql-server
+$COMMAND build base
+$COMMAND build test-base sql-server
 
 # This log file is useful for debugging test failures
 TEST_LOG=$BIN_DIR/test.log

--- a/base/docker/scripts/embeddings/embeddings.py
+++ b/base/docker/scripts/embeddings/embeddings.py
@@ -196,12 +196,12 @@ class Embedder():
                         properties: dict,
                         descriptor_set: str,
                         device: Optional[Literal["cpu", "cuda"]] = None) -> "Embedder":
-    """Create an Embedder instance from properties."""
-    provider = properties.get("embeddings_provider")
-     model_name = properties.get("embeddings_model")
-      pretrained = properties.get("embeddings_pretrained")
+        """Create an Embedder instance from properties."""
+        provider = properties.get("embeddings_provider")
+        model_name = properties.get("embeddings_model")
+        pretrained = properties.get("embeddings_pretrained")
 
-       if not provider or not model_name or not pretrained:
+        if not provider or not model_name or not pretrained:
             raise ValueError(
                 f"Properties must contain 'embeddings_provider', 'embeddings_model', and 'embeddings_pretrained': {descriptor_set} - {properties}.")
 

--- a/compose.sh
+++ b/compose.sh
@@ -21,11 +21,25 @@ else
   DESCRIPTION_SUFFIX=""
 fi
 
-
-# CI should provide these variables, but we need defaults for local builds
-export VERSION="${VERSION:-local}"
 GITHUB_SHA="${GITHUB_SHA:-$(git -C "$TOP" rev-parse HEAD)}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aperture-data/workflows}"
+
+# if VERSION is set use it, or build from githash
+if [ -n "${VERSION:-}" ]; then
+  echo "Using version: $VERSION"
+else
+  echo "Building version from git hash: $GITHUB_SHA"
+  SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-12)
+  VERSION="local-$SHORT_SHA"
+  if [ -n "${IS_DIRTY}" ]; then
+    echo "Repository is dirty, appending dirty hash to version."
+    DIRTY_HASH=$( { git diff --cached --no-ext-diff ; git diff --no-ext-diff ; } | sha1sum | cut -c1-12)
+    VERSION="${VERSION}-${DIRTY_HASH}"
+  fi
+  echo "Computed version: $VERSION"
+fi
+export VERSION
+
 
 export GITHUB_SHA_FULL="${GITHUB_SHA}${SHA_SUFFIX}"
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
In this PR, I change the VERSION string generated by ./compose.sh to be based on the git hash plus an optional dirty hash.
This avoids the problem with "local" whereby docker compose runs tests with old versions because it treats tags as immutable and doesn't recheck their hash. This still takes advantage of layer caching, because the computed hashes should be the same when there is no change.

Also fixed more merge problem in embedding.py.