### PR TITLE
force test script version to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
           WF_DATA_SOURCE_GCP_BUCKET: ${{ secrets.WF_DATA_SOURCE_GCP_BUCKET }}
         run: |
           cd apps/${{ matrix.app }}
-          bash test.sh || bash ../build.sh
+          VERSION=latest bash test.sh || bash ../build.sh
 
       - name: Push to docker (on main)
         # Only push to docker when merged to main


### PR DESCRIPTION
It's hard to test, but I think this change will fix the problems seen in https://github.com/aperture-data/workflows/actions/runs/17143154707/job/48641084984#step:7:83

We have two ways to build workflows (which we should unify). The old way uses `build.sh`, and always tags its builds as `latest`. The new way uses `compose.sh`, and uses VERSION for the tag if supplied, or invents its own tag based on git hashes. In CI, VERSION is set to the new version number we want the images to be tagged with, but we assume that the build scripts don't honor that. So we have a step that retags `latest` into the desired version tag.

What this change does is to force the `VERSION` envar to be `latest`, just for running test scripts. This forces `compose.sh` to tag the image as `latest`, which is what CI expects. In the future, when we change all builds to be based on `compose.sh`, we can change the CI behaviour and never tag as `latest`.