### PR TITLE
Remove password leaked on logs

### DIFF
--- a/apps/sql-server/app/app.sh
+++ b/apps/sql-server/app/app.sh
@@ -54,8 +54,6 @@ until pg_isready -U postgres -h /var/run/postgresql ; do
   sleep 1
 done
 
-# Set the password for the 'aperturedb' user
-echo "Setting $SQL_USER password... to $SQL_PASS"
 # Be careful to avoid problems with special characters in the password
 su - postgres -c "psql" <<EOF
 DO \$\$


### PR DESCRIPTION
Logs:

```
Starting ApertureDB proxy server...
Using provided TLS certificates for PostgreSQL.
Starting PostgreSQL...
 * Starting PostgreSQL 17 database server
Usage: uvicorn [OPTIONS] APP
Try 'uvicorn --help' for help.

Error: Invalid value for '--log-level': 'warn' is not one of 'critical', 'error', 'warning', 'info', 'debug', 'trace'.
   ...done.
/var/run/postgresql:5432 - accepting connections
Setting aperturedb password... to zwmm78ep#TbYLzHI3sNx?_*r3B!*Xl6(
DO
Checking database exists and user can access it...
Loading SQL file: types.sql
-- Enums
CREATE TYPE image_format_enum AS ENUM ('png', 'jpg');
CREATE TYPE
CREATE TYPE video_codec_enum AS ENUM ('xvid', 'h263', 'h264');
CREATE TYPE
CREATE TYPE video_container_enum AS ENUM('mp4', 'avi', 'mov');
CREATE TYPE
Successfully loaded SQL file: types.sql
```