### PR TITLE
fix two small problems

### DIFF
--- a/apps/sql-server/app/app.py
+++ b/apps/sql-server/app/app.py
@@ -19,7 +19,7 @@ app = FastAPI(
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
-LOG_LEVEL = os.getenv("WF_LOG_LEVEL", "WARN").upper()
+LOG_LEVEL = os.getenv("WF_LOG_LEVEL", "WARNING").upper()
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
 

--- a/apps/sql-server/app/app.sh
+++ b/apps/sql-server/app/app.sh
@@ -4,7 +4,7 @@ set -e
 # Dump log file on error
 trap 'echo "An error occurred. Check the logs for details."; cat /tmp/fdw.log' ERR
 
-WF_LOG_LEVEL=${WF_LOG_LEVEL:-WARN}
+WF_LOG_LEVEL=${WF_LOG_LEVEL:-WARNING}
 echo "WF_LOG_LEVEL=$WF_LOG_LEVEL" >>/app/aperturedb.env
 
 # Start proxy server
@@ -49,7 +49,7 @@ fi
 echo "Starting PostgreSQL..."
 /etc/init.d/postgresql start
 
-until pg_isready -U postgres -h /var/run/postgresql ; do
+until su - postgres -c "pg_isready -h /var/run/postgresql"; do
   echo "Waiting for postgres..."
   sleep 1
 done
@@ -57,7 +57,7 @@ done
 # Set the password for the 'aperturedb' user
 echo "Setting $SQL_USER password... to $SQL_PASS"
 # Be careful to avoid problems with special characters in the password
-su - postgres -c "psql" <<EOF
+su - postgres -c "psql <<'EOF'
 DO \$\$
 BEGIN
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${SQL_USER}') THEN
@@ -68,7 +68,7 @@ BEGIN
   END IF;
 END;
 \$\$;
-EOF
+EOF"
 su - postgres -c "set -e ; createdb ${SQL_NAME}"
 
 

--- a/apps/sql-server/fdw/fdw/common.py
+++ b/apps/sql-server/fdw/fdw/common.py
@@ -32,8 +32,8 @@ def load_aperturedb_env(path="/app/aperturedb.env"):
 def get_log_level() -> int:
     """Get the log level from the environment variable."""
     load_aperturedb_env()
-    log_level = os.getenv("WF_LOG_LEVEL", "WARN").upper()
-    return getattr(logging, log_level, logging.WARN)
+    log_level = os.getenv("WF_LOG_LEVEL", "WARNING").upper()
+    return getattr(logging, log_level, logging.WARNING)
 
 
 # Mapping from ApertureDB types to PostgreSQL types.


### PR DESCRIPTION
This PR does two things:
* Sets default log level to be "WARNING" rather than "WARN". Some components (Uvicorn) are more fussy about log levels.
* Fixes some apparently harmless issues with the shell script that caused messages about using "postgres" user as root.