### PR TITLE
add typer to postgres python dependencies

### DIFF
--- a/apps/sql-server/Dockerfile
+++ b/apps/sql-server/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone --single-branch --branch main https://github.com/pgsql-io/multicor
  && make PYTHON=/usr/bin/python3 \
  && make install
 
-RUN pip install --no-cache-dir numpy pydantic dotenv
+RUN pip install --no-cache-dir numpy pydantic dotenv typer
 
 # Copy and install our FDW into system Python
 COPY fdw /fdw


### PR DESCRIPTION
Because of the way the base image uses `sitecustomize.py`, its exception handler is invoked under uncaught exceptions in all Python code on the platform. This is normally fine because such Python runs under our virtual environment. In the case of sql-server, however, the Python running under PostgreSQL runs in a special environment with minimal dependencies.  This means we need to add the `typer` dependency because the global exception handler relies on it.