### PR TITLE
Stricter validation of celeba images.

### DIFF
--- a/apps/dataset-ingestion/app/build_faces/validate_db.py
+++ b/apps/dataset-ingestion/app/build_faces/validate_db.py
@@ -16,17 +16,36 @@ count_queries = [
                 }
             }
         }],
-        [{
+        [{ "FindImage": {
+            "_ref": 1,
+            "constraints": {
+                "Bald": ["!=", None]
+            },
+            "blobs": False
+        }},
+            {
             "FindDescriptor":{
                 "set": "ViT-B/16",
+                "is_connected_to":{
+                    "ref": 1
+                },
                 "results": {
                     "count": True
                 }
             }
         }],
-        [{
+        [{ "FindImage": {
+            "_ref": 1,
+            "constraints": {
+                "Bald": ["!=", None]
+            },
+            "blobs": False
+        }},{
             "FindDescriptor":{
                 "set": "ViT-B/16",
+                "is_connected_to":{
+                    "ref": 1
+                },
                 "results": {
                     "count": True
                 }
@@ -104,7 +123,7 @@ for in_csv, cquery in zip(in_csvs, count_queries):
     r, resp, b = execute_batch(q=cquery, blobs=[], db=db)
     print(f"Executing query {cquery} for {in_csv}")
     exp_num = len(df)
-    actual_num = resp[0][list(resp[0].keys())[0]]['count']
+    actual_num = resp[-1][list(resp[-1].keys())[0]]['count']
     print(f"Expected count [{in_csv}]: {exp_num}, Actual count: {actual_num}")
     results.append(exp_num == actual_num)
 


### PR DESCRIPTION
Since celeba and coco use the same descriptorset for clip embeddings, the modified query is required to accurately validate the descriptors when both the datasets are ingested.