### PR TITLE
Fixes from demo prep

### DIFF
--- a/apps/jupyterlab/app/notebooks/sql.ipynb
+++ b/apps/jupyterlab/app/notebooks/sql.ipynb
@@ -298,7 +298,8 @@
    "id": "3e91ab35",
    "metadata": {},
    "source": [
-    "Now we look at a specific connection table."
+    "Now we look at a specific connection table.\n",
+    "We pick a non-system class so that we can see some properties."
    ]
   },
   {
@@ -308,7 +309,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "connection_class = list_tables('connection').table_name[0]\n",
+    "non_system_connection_classes = [ table for table in list_tables('connection').table_name if table[0] != '_' ]\n",
+    "connection_class = non_system_connection_classes[0]\n",
     "print(f\"Using connection class: {connection_class}\")\n",
     "display(run_query(f\"SELECT * FROM connection.\\\"{connection_class}\\\" LIMIT 5;\"))"
    ]

--- a/apps/sql-server/fdw/fdw/__init__.py
+++ b/apps/sql-server/fdw/fdw/__init__.py
@@ -54,6 +54,7 @@ TYPE_SIZE_ESTIMATE = {
     "json": 100,  # average JSON size
     "blob": 1000,  # average blob size
     "uniqueid": 16,  # UUID size
+    None: 10,  # default size, for columns that are not listable
 }
 
 

--- a/apps/sql-server/fdw/fdw/table.py
+++ b/apps/sql-server/fdw/fdw/table.py
@@ -155,6 +155,7 @@ def connection(class_name: Optional[str],
 
     # cases 1, 2, 3, or 4
     if other_columns or other_constraints or not (src_command and dst_command):
+        # See https://github.com/aperture-data/athena/issues/1746
         assert not is_system_class, \
             "Cannot use FindConnection with other constraints or columns on a system class"
         command_body["constraints"] = other_constraints


### PR DESCRIPTION
* Make sure that we don't run a query that will ask for properties from a system connection class. 
* Handle width calculation for certain non-listable fields
* Mark system connection table restriction with issue number. Maybe there's a better way to deal with this, but I'm too tired to think of it right now.