### PR TITLE
improve messages and treat None differently

### DIFF
--- a/base/docker/scripts/embeddings/embeddings.py
+++ b/base/docker/scripts/embeddings/embeddings.py
@@ -251,15 +251,30 @@ class Embedder():
                 f"Found existing descriptor set {descriptor_set}: {existing_properties}")
 
             # Verify that the existing descriptor set matches the requested parameters
+            # We allow None values of the existing properties to allow for re-use of descriptor sets that were created with an earlier version of the code.
             if provider != existing_properties['embeddings_provider']:
-                raise ValueError(
-                    f"Provider mismatch: {provider} != {existing_properties['embeddings_provider']}")
+                if existing_properties['embeddings_provider'] is not None:
+                    raise ValueError(
+                        f"Provider mismatch: {provider} != {existing_properties['embeddings_provider']} in descriptor set {descriptor_set}, properties: {existing_properties}")
+                else:
+                    logger.warning(
+                        f"Provider mismatch: {provider} != {existing_properties['embeddings_provider']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
+
             if model_name != existing_properties['embeddings_model']:
-                raise ValueError(
-                    f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']}")
-            if pretrained and pretrained != existing_properties['embeddings_pretrained']:
-                raise ValueError(
-                    f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']}")
+                if existing_properties['embeddings_model'] is not None:
+                    raise ValueError(
+                        f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']} in descriptor set {descriptor_set}, properties: {existing_properties}")
+                else:
+                    logger.warning(
+                        f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
+
+            if pretrained and pretrained != existing_properties['embeddings_pretrained'] and existing_properties['embeddings_pretrained'] is not None:
+                if existing_properties['embeddings_pretrained'] is not None:
+                    raise ValueError(
+                        f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']} in descriptor set {descriptor_set}, properties: {existing_properties}")
+                else:
+                    logger.warning(
+                        f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
         else:
             logger.info(
                 f"Descriptor set {descriptor_set} not found. Will create a new one.")


### PR DESCRIPTION
https://aperturedata.slack.com/archives/C08CF1EGT8F/p1758054039469239

This PR means that if we previously used an instance with an earlier version of workflows that did not use the embeddings library, then we will just assume that the embedding models are compatible and reuse an existing descriptor set.