### PR TITLE
Update descriptor set if properties missing

### DIFF
--- a/base/docker/scripts/embeddings/aperturedb_io.py
+++ b/base/docker/scripts/embeddings/aperturedb_io.py
@@ -94,6 +94,25 @@ def add_descriptor_set(
             f"Failed to add descriptor set {descriptor_set}: {query} {client.get_last_response_str()}")
 
 
+def update_descriptor_set(client: Connector,
+                          descriptor_set: str,
+                          properties: dict) -> None:
+    """
+    Update a descriptor set in the database.
+    """
+    query = [{
+        "UpdateDescriptorSet": {
+            "with_name": descriptor_set,
+            "properties": properties
+        }
+    }]
+    execute_query(client, query)
+    if not client.last_query_ok():
+        raise RuntimeError(
+            f"Failed to update descriptor set {descriptor_set}: {query} {client.get_last_response_str()}")
+    logger.info(f"Descriptor set {descriptor_set} updated.")
+
+
 def delete_descriptor_set(client: Connector,
                           descriptor_set: str) -> None:
     """

--- a/base/docker/scripts/embeddings/embeddings.py
+++ b/base/docker/scripts/embeddings/embeddings.py
@@ -251,15 +251,30 @@ class Embedder():
                 f"Found existing descriptor set {descriptor_set}: {existing_properties}")
 
             # Verify that the existing descriptor set matches the requested parameters
+            # We allow None values of the existing properties to allow for re-use of descriptor sets that were created with an earlier version of the code.
             if provider != existing_properties['embeddings_provider']:
-                raise ValueError(
-                    f"Provider mismatch: {provider} != {existing_properties['embeddings_provider']}")
+                if existing_properties['embeddings_provider'] is not None:
+                    raise ValueError(
+                        f"Provider mismatch: {provider} != {existing_properties['embeddings_provider']} in descriptor set {descriptor_set}, properties: {existing_properties}")
+                else:
+                    logger.warning(
+                        f"Provider mismatch: {provider} != {existing_properties['embeddings_provider']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
+
             if model_name != existing_properties['embeddings_model']:
-                raise ValueError(
-                    f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']}")
-            if pretrained and pretrained != existing_properties['embeddings_pretrained']:
-                raise ValueError(
-                    f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']}")
+                if existing_properties['embeddings_model'] is not None:
+                    raise ValueError(
+                        f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']} in descriptor set {descriptor_set}, properties: {existing_properties}")
+                else:
+                    logger.warning(
+                        f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
+
+            if pretrained and pretrained != existing_properties['embeddings_pretrained'] and existing_properties['embeddings_pretrained'] is not None:
+                if existing_properties['embeddings_pretrained'] is not None:
+                    raise ValueError(
+                        f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']} in descriptor set {descriptor_set}, properties: {existing_properties}")
+                else:
+                    logger.warning(
+                        f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
         else:
             logger.info(
                 f"Descriptor set {descriptor_set} not found. Will create a new one.")

--- a/base/docker/scripts/embeddings/embeddings.py
+++ b/base/docker/scripts/embeddings/embeddings.py
@@ -268,7 +268,7 @@ class Embedder():
                     logger.warning(
                         f"Model name mismatch: {model_name} != {existing_properties['embeddings_model']} in descriptor set {descriptor_set}, properties: {existing_properties}. Allowing re-use of descriptor set.")
 
-            if pretrained and pretrained != existing_properties['embeddings_pretrained'] and existing_properties['embeddings_pretrained'] is not None:
+            if pretrained and pretrained != existing_properties['embeddings_pretrained']:
                 if existing_properties['embeddings_pretrained'] is not None:
                     raise ValueError(
                         f"Pretrained corpus mismatch: {pretrained} != {existing_properties['embeddings_pretrained']} in descriptor set {descriptor_set}, properties: {existing_properties}")


### PR DESCRIPTION
Extends https://github.com/aperture-data/workflows/pull/205

This PR extends PR 205 so that the missing properties are updated into the existing descriptor set. This provides some protection for subsequent workflows, and might provide a more consistent experience for client tools (e.g. WebUI semantic search).