### PR TITLE
default value for allowed origins.

### DIFF
--- a/apps/rag/app/app.py
+++ b/apps/rag/app/app.py
@@ -472,7 +472,7 @@ def get_args(argv=[]):
 
     obj.add_argument('--allowed-origins',
                      help='Comma-separated list of allowed origins for CORS',
-                     default="")
+                     default="http://localhost")
 
     obj.add_argument('--aimon-api-key',
                      help='API key for AIMON',


### PR DESCRIPTION
This is useful when the only use for crawl to rag is via notebook