### PR TITLE
Sql enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 apps/dataset-ingestion/input
 log.txt
 input/
+logs/

--- a/apps/sql-server/fdw/fdw/__init__.py
+++ b/apps/sql-server/fdw/fdw/__init__.py
@@ -606,6 +606,8 @@ class FDW(ForeignDataWrapper):
 
         n_rows = self._options.count
         for col, constraints in command_body.get("constraints", {}).items():
+            if col not in self._columns:
+                continue
             col_type = self._columns[col].type
             if col == "_uniqueid":
                 if constraints[0] == "==":

--- a/apps/sql-server/fdw/fdw/column.py
+++ b/apps/sql-server/fdw/fdw/column.py
@@ -100,6 +100,16 @@ def passthrough(name: str,
     command_body[name] = value
 
 
+def passthrough_lowercase(name: str,
+                value: Any, command_body: Dict[str, Any]) -> None:
+    """
+    A ColumnOptions modify_command_body hook.
+
+    Adds the value to the command body under the given name in lowercase.
+    """
+    command_body[name] = value.lower()
+
+
 def add_blob(column: str,
              value: Any, row: dict, blob: Optional[bytes]) -> None:
     """

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -6,7 +6,7 @@
 # SELECT * FROM "DescriptorSet" LIMIT 10;
 
 from typing import List, Literal, Set, Any, Dict
-from .column import property_columns, ColumnOptions, blob_columns, uniqueid_column, passthrough, get_path_keys
+from .column import property_columns, ColumnOptions, blob_columns, uniqueid_column, passthrough_lowercase, get_path_keys
 from .table import TableOptions, literal, connection as table_connection
 from .common import TYPE_MAP, Curry
 from .aperturedb import get_classes
@@ -98,7 +98,7 @@ def image_extra_columns() -> List[ColumnDefinition]:
             type_name="text",
             options=ColumnOptions(
                 listable=False,
-                modify_command_body=Curry(passthrough, "as_format"),
+                modify_command_body=Curry(passthrough_lowercase, "as_format"),
             ).to_string()
         ),
         operations_column({"threshold", "resize", "crop", "rotate", "flip"}),

--- a/apps/sql-server/test/docker-compose.yml
+++ b/apps/sql-server/test/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       timeout: 1s
       retries: 60
     ports: []
+    volumes:
+      - ./aperturedb/logs:/aperturedb/logs
+    environment:
+      ADB_ENABLE_DEBUG: 1
+      ADB_LOG_PATH: "logs"
 
   # One image for both seed and tests (Python + aperturedb + pytest + psycopg)
   # Use the same image; just change the command.

--- a/apps/sql-server/test/seed.py
+++ b/apps/sql-server/test/seed.py
@@ -1,4 +1,4 @@
-from aperturedb.CommonLibrary import execute_query
+from aperturedb.CommonLibrary import execute_query, create_connector
 from aperturedb.Connector import Connector
 from itertools import product
 import os
@@ -231,14 +231,23 @@ def load_blobs_testdata(client):
     assert status == 0
 
 
-if __name__ == "__main__":
+def db_connection():
+    """Create a database connection."""
+    # Not used in testing, but can be used to seed a different database
+    APERTUREDB_KEY = os.getenv("APERTUREDB_KEY")
+    if APERTUREDB_KEY:
+        return create_connector(key=APERTUREDB_KEY)
+
     DB_HOST = os.getenv("DB_HOST", "aperturedb")
     DB_PORT = int(os.getenv("DB_PORT", "55555"))
     DB_USER = os.getenv("DB_USER", "admin")
     DB_PASS = os.getenv("DB_PASS", "admin")
-    print(f"{DB_HOST=}, {DB_PORT=}, {DB_USER=}, {DB_PASS}")
-    client = Connector(host=DB_HOST, user=DB_USER,
-                       port=DB_PORT, password=DB_PASS)
+    return Connector(host=DB_HOST, user=DB_USER, port=DB_PORT, password=DB_PASS)
+
+
+
+if __name__ == "__main__":
+    client = db_connection()
 
     print(f"host={client.host}")
     load_constraints_testdata(client)

--- a/apps/sql-server/test/seed.py
+++ b/apps/sql-server/test/seed.py
@@ -102,6 +102,12 @@ def random_images(n=10):
         images.append(img_byte_arr.getvalue())
     return images
 
+def random_blobs(n=10):
+    """
+    Generate a list of random blobs for testing.
+    """
+    return [np.random.bytes(np.random.randint(100, 1000)) for _ in range(n)]
+
 
 def random_embedding(dimensions):
     """
@@ -208,6 +214,23 @@ def load_images_testdata(client):
     assert status == 0
 
 
+def load_blobs_testdata(client):
+    """
+    Create some test data for the blob suite.
+    """
+    query = []
+    blobs = random_blobs(10)
+
+    for blob in blobs:
+        query.append({
+            "AddBlob": {
+            }
+        })        
+
+    status, _, _ = execute_query(client, query, blobs)
+    assert status == 0
+
+
 if __name__ == "__main__":
     DB_HOST = os.getenv("DB_HOST", "aperturedb")
     DB_PORT = int(os.getenv("DB_PORT", "55555"))
@@ -221,6 +244,7 @@ if __name__ == "__main__":
     load_constraints_testdata(client)
     load_text_descriptors_testdata(client)
     load_images_testdata(client)
+    load_blobs_testdata(client)
     print("Test data loaded successfully.")
 
     _, results, _ = execute_query(client, [{"GetSchema": {}}])

--- a/apps/sql-server/test/test_blob.py
+++ b/apps/sql-server/test/test_blob.py
@@ -1,0 +1,196 @@
+import os
+import json
+import pytest
+import psycopg2
+from psycopg2.extras import Json
+import numpy as np
+from typing import List
+import base64
+
+
+@pytest.fixture(scope="session")
+def sql_connection():
+    conn = psycopg2.connect(
+        host=os.getenv("SQL_HOST", "sql-server"),
+        port=os.getenv("SQL_PORT", "5432"),
+        dbname=os.getenv("SQL_NAME", "aperturedb"),
+        user=os.getenv("SQL_USER", "aperturedb"),
+        password=os.getenv("SQL_PASS", "test"),
+    )
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+class TestBlob:
+    """Test blob retrieval"""
+
+    def test_blob_retrieval_without_blobs_flag(self, sql_connection):
+        """
+        Test that blob data is not returned when _blobs flag is not set.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs = FALSE
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows but _blob column should be None
+        for row in result:
+            assert row[1] is None, f"Expected _blob to be None when _blobs=FALSE, got: {type(row[1])}"
+
+    def test_blob_retrieval_with_blobs_flag(self, sql_connection):
+        """
+        Test that blob data is returned when _blobs flag is set.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs = TRUE
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with actual blob data
+        for row in result:
+            assert row[1] is not None, f"Expected _blob to contain data when _blobs=TRUE, got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _blob to be bytes, got: {type(row[1])}"
+
+    def test_blob_retrieval_with_blobs_is_true(self, sql_connection):
+        """
+        Test that blob data is returned when _blobs IS TRUE.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs IS TRUE
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with actual blob data
+        for row in result:
+            assert row[1] is not None, f"Expected _blob to contain data when _blobs IS TRUE, got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _blob to be bytes, got: {type(row[1])}"
+
+    def test_blob_retrieval_with_not_blobs(self, sql_connection):
+        """
+        Test that blob data is not returned when NOT _blobs.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE NOT _blobs
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows but _blob column should be None
+        for row in result:
+            assert row[1] is None, f"Expected _blob to be None when NOT _blobs, got: {type(row[1])}"
+
+    def test_blob_retrieval_with_blobs_not_equal_true(self, sql_connection):
+        """
+        Test that blob data is not returned when _blobs <> TRUE.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs <> TRUE
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows but _blob column should be None
+        for row in result:
+            assert row[1] is None, f"Expected _blob to be None when _blobs <> TRUE, got: {type(row[1])}"
+
+    def test_blob_retrieval_with_blobs_is_false(self, sql_connection):
+        """
+        Test that blob data is not returned when _blobs IS FALSE.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs IS FALSE
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows but _blob column should be None
+        for row in result:
+            assert row[1] is None, f"Expected _blob to be None when _blobs IS FALSE, got: {type(row[1])}"
+
+    def test_blob_retrieval_with_blobs_is_not_true(self, sql_connection):
+        """
+        Test that blob data is not returned when _blobs IS NOT TRUE.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs IS NOT TRUE
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows but _blob column should be None
+        for row in result:
+            assert row[1] is None, f"Expected _blob to be None when _blobs IS NOT TRUE, got: {type(row[1])}"
+
+
+    def test_blob_retrieval_with_properties(self, sql_connection):
+        """
+        Test that blob retrieval works with property filtering.
+        """
+        sql = """
+        SELECT _uniqueid, _blob FROM system."Blob" 
+        WHERE _blobs = TRUE
+        AND _uniqueid IS NOT NULL
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with actual blob data
+        for row in result:
+            assert row[1] is not None, f"Expected _blob to contain data when _blobs=TRUE with properties, got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _blob to be bytes, got: {type(row[1])}"
+
+
+    def test_blob_count_without_blobs(self, sql_connection):
+        """
+        Test that COUNT works correctly without blob retrieval.
+        """
+        sql = """
+        SELECT COUNT(*) FROM system."Blob" 
+        WHERE _blobs = FALSE;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchone()
+        
+        assert result[0] >= 0, f"Expected count to be non-negative, got: {result[0]}"
+
+    def test_blob_count_with_blobs(self, sql_connection):
+        """
+        Test that COUNT works correctly with blob retrieval.
+        """
+        sql = """
+        SELECT COUNT(*) FROM system."Blob" 
+        WHERE _blobs = TRUE;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchone()
+        
+        assert result[0] >= 0, f"Expected count to be non-negative, got: {result[0]}"

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -279,6 +279,8 @@ def multicorn_plan(plan_node: dict) -> str:
     pytest.param("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};",
                  marks=pytest.mark.xfail(
                      reason="https://github.com/aperture-data/athena/issues/1737")),
+    "SELECT * FROM connection.\"_DescriptorConnection\";",
+    "SELECT * FROM connection.\"edge\";",
 ])
 def test_join_query(query, sql_connection, constraint_formatter):
     """

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -258,31 +258,33 @@ def multicorn_plan(plan_node: dict) -> str:
     return None
 
 
-@pytest.mark.parametrize("query", [
-    "SELECT source_key FROM \"SourceNode\";",
-    "SELECT destination_key FROM \"DestinationNode\";",
-    "SELECT edge_key FROM \"edge\";",
-    "SELECT source_key, edge_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON B._src = A._uniqueid;",
-    "SELECT source_key, edge_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON B._src = A._uniqueid WHERE source_key = edge_key;",
-    "SELECT destination_key, edge_key FROM \"DestinationNode\" AS A JOIN \"edge\" AS B ON B._dst = A._uniqueid;",
-    "SELECT destination_key, edge_key FROM \"DestinationNode\" AS A JOIN \"edge\" AS B ON B._dst = A._uniqueid WHERE destination_key = edge_key;",
-    "SELECT source_key, destination_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON A._uniqueid = B._src JOIN \"DestinationNode\" AS C ON B._dst = C._uniqueid;",
-    "SELECT source_key, destination_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON A._uniqueid = B._src JOIN \"DestinationNode\" AS C ON B._dst = C._uniqueid WHERE source_key = destination_key;",
-    "SELECT source_key FROM \"SourceNode\" WHERE _uniqueid in {src_unique_ids};",
-    "SELECT destination_key FROM \"DestinationNode\" WHERE _uniqueid in {dst_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _dst IN {dst_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids};",
-    "SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _dst IN {dst_unique_ids};",
-    pytest.param("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};",
+@pytest.mark.parametrize("query,n_results", [
+    ("SELECT source_key FROM \"SourceNode\";", 5),
+    ("SELECT destination_key FROM \"DestinationNode\";", 5),
+    ("SELECT edge_key FROM \"edge\";", 5),
+    ("SELECT source_key, edge_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON B._src = A._uniqueid;", 5),
+    ("SELECT source_key, edge_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON B._src = A._uniqueid WHERE source_key = edge_key;", 5),
+    ("SELECT destination_key, edge_key FROM \"DestinationNode\" AS A JOIN \"edge\" AS B ON B._dst = A._uniqueid;", 5),
+    ("SELECT destination_key, edge_key FROM \"DestinationNode\" AS A JOIN \"edge\" AS B ON B._dst = A._uniqueid WHERE destination_key = edge_key;", 5),
+    ("SELECT source_key, destination_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON A._uniqueid = B._src JOIN \"DestinationNode\" AS C ON B._dst = C._uniqueid;", 5),
+    ("SELECT source_key, destination_key FROM \"SourceNode\" AS A JOIN \"edge\" AS B ON A._uniqueid = B._src JOIN \"DestinationNode\" AS C ON B._dst = C._uniqueid WHERE source_key = destination_key;", 5),
+    ("SELECT source_key FROM \"SourceNode\" WHERE _uniqueid in {src_unique_ids};", 5),
+    ("SELECT destination_key FROM \"DestinationNode\" WHERE _uniqueid in {dst_unique_ids};", 5),
+    ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids};", 5),
+    ("SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids};", 5),
+    ("SELECT edge_key FROM \"edge\" WHERE _dst IN {dst_unique_ids};", 5),
+    pytest.param("SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5,
+                  marks=pytest.mark.xfail(
+                      reason="https://github.com/aperture-data/athena/issues/1737")),
+    ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids};", 5),
+    ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _dst IN {dst_unique_ids};", 5),
+    pytest.param("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5,
                  marks=pytest.mark.xfail(
                      reason="https://github.com/aperture-data/athena/issues/1737")),
-    "SELECT * FROM connection.\"_DescriptorConnection\";",
-    "SELECT * FROM connection.\"edge\";",
+    ("SELECT * FROM connection.\"_DescriptorConnection\";", 20),
+    ("SELECT * FROM connection.\"edge\";", 5),
 ])
-def test_join_query(query, sql_connection, constraint_formatter):
+def test_join_query(query, n_results, sql_connection, constraint_formatter):
     """
     Test the execution of join queries.
     """
@@ -297,7 +299,7 @@ def test_join_query(query, sql_connection, constraint_formatter):
         raise
 
     assert len(
-        result) == 5, f"Expected 5 rows, got {len(result)} for query: {query}, {query_aql(query, sql_connection)}"
+        result) == n_results, f"Expected {n_results} rows, got {len(result)} for query: {query}, {query_aql(query, sql_connection)}"
 
 
 def query_aql(query: str, sql_connection) -> str:

--- a/apps/sql-server/test/test_image.py
+++ b/apps/sql-server/test/test_image.py
@@ -1,0 +1,246 @@
+import os
+import json
+import pytest
+import psycopg2
+from psycopg2.extras import Json
+from PIL import Image
+from io import BytesIO
+
+
+@pytest.fixture(scope="session")
+def sql_connection():
+    conn = psycopg2.connect(
+        host=os.getenv("SQL_HOST", "sql-server"),
+        port=os.getenv("SQL_PORT", "5432"),
+        dbname=os.getenv("SQL_NAME", "aperturedb"),
+        user=os.getenv("SQL_USER", "aperturedb"),
+        password=os.getenv("SQL_PASS", "test"),
+    )
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+def validate_image_format(image_bytes, expected_format):
+    """
+    Validate that the image bytes are in the expected format.
+    """
+    if image_bytes is None:
+        return False
+    
+    try:
+        # Try to open the image with PIL
+        image = Image.open(BytesIO(image_bytes))
+        actual_format = image.format.upper()
+        expected_format_upper = expected_format.upper()
+        
+        # Handle JPEG vs JPG
+        if expected_format_upper == 'JPG':
+            expected_format_upper = 'JPEG'
+        
+        return actual_format == expected_format_upper
+    except Exception:
+        return False
+
+
+# Test parameters for different formats and operations
+FORMATS = ['png', 'jpg', 'PNG', 'JPG', 'Png', 'Jpg']
+OPERATIONS = [
+    None,  # No operations
+    'OPERATIONS(RESIZE(width := 100, height := 100))',
+    'OPERATIONS(CROP(x := 10, y := 10, width := 50, height := 50))',
+    'OPERATIONS(ROTATE(angle := 90))',
+    'OPERATIONS(FLIP(code := 1))',
+    'OPERATIONS(THRESHOLD(value := 128))',
+    'OPERATIONS(THRESHOLD(value := 64), CROP(x := 10, y := 10, width := 50, height := 50), FLIP(code := 1), ROTATE(angle := 90), RESIZE(width := 50))'
+]
+
+
+class TestImage:
+    """Test the _as_format functionality for image operations."""
+
+    @pytest.mark.parametrize("format_val", FORMATS)
+    def test_as_format_basic(self, sql_connection, format_val):
+        """
+        Test basic _as_format functionality for different formats.
+        """
+        sql = f"""
+        SELECT _uniqueid, _image FROM system."Image" 
+        WHERE _blobs = TRUE
+        AND _as_format = '{format_val}'
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with image data
+        for row in result:
+            assert row[1] is not None, f"Expected _image to contain data when _as_format='{format_val}', got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _image to be bytes, got: {type(row[1])}"
+            
+            # Validate the image format
+            assert validate_image_format(row[1], format_val), f"Expected image to be in {format_val} format, but validation failed"
+
+    @pytest.mark.parametrize("format_val", FORMATS)
+    @pytest.mark.parametrize("operation", OPERATIONS)
+    def test_as_format_with_operations(self, sql_connection, format_val, operation):
+        """
+        Test _as_format combined with various operations.
+        """
+        if operation is None:
+            # Test without operations
+            sql = f"""
+            SELECT _uniqueid, _image FROM system."Image" 
+            WHERE _blobs = TRUE
+            AND _as_format = '{format_val}'
+            LIMIT 5;
+            """
+        else:
+            # Test with operations
+            sql = f"""
+            SELECT _uniqueid, _image FROM system."Image" 
+            WHERE _blobs = TRUE
+            AND _as_format = '{format_val}'
+            AND _operations = {operation}
+            LIMIT 5;
+            """
+        
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with image data
+        for row in result:
+            assert row[1] is not None, f"Expected _image to contain data when _as_format='{format_val}' with operation={operation}, got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _image to be bytes, got: {type(row[1])}"
+            
+            # Validate the image format
+            assert validate_image_format(row[1], format_val), f"Expected image to be in {format_val} format with operation={operation}, but validation failed"
+
+    @pytest.mark.parametrize("format_val", FORMATS)
+    def test_as_format_without_blobs_flag(self, sql_connection, format_val):
+        """
+        Test that _as_format works even without _blobs flag (should not return blob data).
+        """
+        sql = f"""
+        SELECT _uniqueid, _image FROM system."Image" 
+        WHERE _as_format = '{format_val}'
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows but _image column should be None since _blobs is not set
+        for row in result:
+            assert row[1] is None, f"Expected _image to be None when _as_format='{format_val}' is set but _blobs is not, got: {type(row[1])}"
+
+    @pytest.mark.xfail(reason="Invalid format should fail")
+    @pytest.mark.parametrize("invalid_format", ['gif', 'bmp', 'tiff', 'webp', 'invalid', 'jpeg'])
+    def test_as_format_invalid_format_fails(self, sql_connection, invalid_format):
+        """
+        Test that invalid _as_format values fail appropriately.
+        """
+        sql = f"""
+        SELECT _uniqueid, _image FROM system."Image" 
+        WHERE _blobs = TRUE
+        AND _as_format = '{invalid_format}'
+        LIMIT 1;
+        """
+        
+        # This should raise an exception
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+            
+            assert len(result) == 0, f"Expected no results for invalid format '{invalid_format}', got {len(result)} results"
+
+    @pytest.mark.parametrize("case_format", ['PNG', 'JPG', 'Jpg', 'Png'])
+    def test_as_format_case_insensitive(self, sql_connection, case_format):
+        """
+        Test that _as_format is case insensitive - uppercase formats should work.
+        """
+        sql = f"""
+        SELECT _uniqueid, _image FROM system."Image" 
+        WHERE _blobs = TRUE
+        AND _as_format = '{case_format}'
+        LIMIT 5;
+        """
+        
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with image data
+        for row in result:
+            assert row[1] is not None, f"Expected _image to contain data when _as_format='{case_format}', got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _image to be bytes, got: {type(row[1])}"
+            
+            # Validate the image format (normalize to lowercase for comparison)
+            expected_format = case_format.lower()
+            assert validate_image_format(row[1], expected_format), f"Expected image to be in {expected_format} format, but validation failed"
+
+    @pytest.mark.parametrize("format_val", FORMATS)
+    def test_as_format_with_property_filtering(self, sql_connection, format_val):
+        """
+        Test that _as_format works with property filtering.
+        """
+        sql = f"""
+        SELECT _uniqueid, _image FROM system."Image" 
+        WHERE _blobs = TRUE
+        AND _as_format = '{format_val}'
+        AND _uniqueid IS NOT NULL
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with image data
+        for row in result:
+            assert row[1] is not None, f"Expected _image to contain data when _as_format='{format_val}' with property filtering, got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _image to be bytes, got: {type(row[1])}"
+            
+            # Validate the image format
+            assert validate_image_format(row[1], format_val), f"Expected image to be in {format_val} format with property filtering, but validation failed"
+
+    @pytest.mark.parametrize("format_val", FORMATS)
+    def test_as_format_count_queries(self, sql_connection, format_val):
+        """
+        Test that COUNT queries work with _as_format.
+        """
+        sql = f"""
+        SELECT COUNT(*) FROM system."Image" 
+        WHERE _as_format = '{format_val}';
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchone()
+        
+        assert result[0] >= 0, f"Expected count to be non-negative for _as_format='{format_val}', got: {result[0]}"
+
+    @pytest.mark.parametrize("format_val", FORMATS)
+    def test_as_format_combined_with_multiple_conditions(self, sql_connection, format_val):
+        """
+        Test that _as_format works with multiple WHERE conditions.
+        """
+        sql = f"""
+        SELECT _uniqueid, _image FROM system."Image" 
+        WHERE _blobs = TRUE
+        AND _as_format = '{format_val}'
+        AND _uniqueid IS NOT NULL
+        AND _operations = OPERATIONS(RESIZE(width := 50, height := 50))
+        LIMIT 5;
+        """
+        with sql_connection.cursor() as cur:
+            cur.execute(sql)
+            result = cur.fetchall()
+        
+        # Should return rows with image data
+        for row in result:
+            assert row[1] is not None, f"Expected _image to contain data when _as_format='{format_val}' with multiple conditions, got None"
+            assert isinstance(row[1], (bytes, memoryview)), f"Expected _image to be bytes, got: {type(row[1])}"
+            
+            # Validate the image format
+            assert validate_image_format(row[1], format_val), f"Expected image to be in {format_val} format with multiple conditions, but validation failed"


### PR DESCRIPTION
This is a followup to a SQL demo last week that:
* Adds more unit tests to catch some additional cases, especially for blob retrieval and image operations, but also for complex connection constraints. This includes extending the seed script to add images and blobs.
* Makes the value of `_as_format` case insensitive so that `PNG` and `JPG` will now be accepted.
* Fixes some edge cases in the way we deal with connection JOINs. This means that it should now be possible to do `SELECT * FROM \"connection._DescriptorConnection;` without running into the problem described in https://github.com/aperture-data/athena/issues/1746