### PR TITLE
Sql security

### DIFF
--- a/apps/sql-server/app/sql/access.sql
+++ b/apps/sql-server/app/sql/access.sql
@@ -18,3 +18,28 @@ GRANT SELECT ON ALL TABLES IN SCHEMA connection TO aperturedb;
 GRANT SELECT ON ALL TABLES IN SCHEMA descriptor TO aperturedb;
 
 GRANT USAGE ON FOREIGN SERVER aperturedb TO aperturedb;
+
+-- Lock down public
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+REVOKE CREATE ON SCHEMA public FROM aperturedb;
+
+-- Lock down dangerous PLs just in case
+DROP EXTENSION IF EXISTS plpythonu;
+DROP EXTENSION IF EXISTS plperl;
+
+-- Revoke untrusted languages if they exist
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpythonu') THEN
+        REVOKE USAGE ON LANGUAGE plpythonu FROM PUBLIC;
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plperl') THEN
+        REVOKE USAGE ON LANGUAGE plperl FROM PUBLIC;
+    END IF;
+END;
+$$;

--- a/apps/sql-server/test/docker-compose.yml
+++ b/apps/sql-server/test/docker-compose.yml
@@ -75,4 +75,4 @@ services:
       SQL_USER: aperturedb
       SQL_PASS: test
     working_dir: /app
-    command: ["pytest",  "-vv", "-s", "-rA", "--log-cli-level=DEBUG"]
+    command: ["pytest",  "-vv", "-s", "-rA", "--log-cli-level=DEBUG", "test_security.py"]

--- a/apps/sql-server/test/docker-compose.yml
+++ b/apps/sql-server/test/docker-compose.yml
@@ -75,4 +75,4 @@ services:
       SQL_USER: aperturedb
       SQL_PASS: test
     working_dir: /app
-    command: ["pytest",  "-vv", "-s", "-rA", "--log-cli-level=DEBUG", "test_security.py"]
+    command: ["pytest",  "-vv", "-s", "-rA", "--log-cli-level=DEBUG"]

--- a/apps/sql-server/test/test_security.py
+++ b/apps/sql-server/test/test_security.py
@@ -1,0 +1,291 @@
+import pytest
+import psycopg2
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# List of schemas to test for read-only access
+@dataclass
+class Schema:
+    schema: str
+    table: str
+    foreign: bool
+    column: str
+    value: str = "'test'"
+
+    @property
+    def table_name(self):
+        return f"\"{self.schema}\".\"{self.table}\""
+
+    @property
+    def maybe_foreign(self):
+        return "FOREIGN " if self.foreign else ""
+
+    @property 
+    def is_writable(self):
+        return self.table is not None and not self.foreign
+
+SCHEMAS = [
+    Schema(schema="public", table=None, foreign=False, column=None),
+    Schema(schema="pg_catalog", table="pg_authid", foreign=False, column="rolname"),
+    Schema(schema="descriptor", table="TestText_0", foreign=True, column="_uniqueid"),
+    Schema(schema="entity", table="TestRow", foreign=True, column="_uniqueid"),
+    Schema(schema="connection", table="edge", foreign=True, column="_uniqueid"),
+    Schema(schema="system", table="Image", foreign=True, column="_uniqueid"),
+]
+
+
+
+@pytest.fixture(scope="session")
+def sql_connection():
+    conn = psycopg2.connect(
+        host=os.getenv("SQL_HOST", "sql-server"),
+        port=os.getenv("SQL_PORT", "5432"),
+        dbname=os.getenv("SQL_NAME", "aperturedb"),
+        user=os.getenv("SQL_USER", "aperturedb"),
+        password=os.getenv("SQL_PASS", "test"),
+    )
+    # This line makes sure that one crash doesn't leave the connection in a bad state
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+def test_can_run_simple_select(sql_connection):
+    with sql_connection.cursor() as cur:
+        cur.execute("SELECT 42;")
+        assert cur.fetchone()[0] == 42
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_create_table_in_schema(sql_connection, schema):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"CREATE TABLE {schema.schema}.\"forbidden\"(id INT);")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_drop_table_in_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"DROP {schema.maybe_foreign} TABLE IF EXISTS {schema.table_name};")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_alter_table_in_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"ALTER {schema.maybe_foreign} TABLE {schema.table_name} ADD COLUMN test_col INT;")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_create_index_in_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"CREATE INDEX IF NOT EXISTS test_idx ON {schema.table_name}({schema.column});")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_create_view_in_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"CREATE VIEW {schema.schema}.my_view AS SELECT {schema.table_name}.{schema.column} FROM {schema.table_name};")
+
+
+def test_cannot_create_function_in_plpgsql(sql_connection):
+    with sql_connection.cursor() as cur:
+        cur.execute("DROP FUNCTION IF EXISTS harmless();")
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("""
+                CREATE FUNCTION harmless() RETURNS INTEGER AS $$
+                BEGIN
+                    RETURN 1;
+                END;
+                $$ LANGUAGE plpgsql;
+            """)
+
+
+def test_cannot_create_function_in_plpythonu(sql_connection):
+    with sql_connection.cursor() as cur:
+        cur.execute("DROP FUNCTION IF EXISTS evil();")
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("""
+                CREATE FUNCTION evil() RETURNS TEXT AS $$
+                import os
+                return os.environ.get("DB_PASS", "NOPE")
+                $$ LANGUAGE plpythonu;
+            """)
+
+
+def test_pg_authid_access_blocked(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("SELECT * FROM pg_authid;")
+
+
+def test_create_extension_blocked(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("CREATE EXTENSION IF NOT EXISTS file_fdw;")
+
+
+def test_no_create_trigger(sql_connection):
+    with sql_connection.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS trap CASCADE;")
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("""
+                CREATE TABLE trap(id INT);
+                CREATE FUNCTION trap_fn() RETURNS trigger AS $$
+                BEGIN
+                    RAISE NOTICE 'Triggered';
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+                CREATE TRIGGER trg BEFORE INSERT ON trap FOR EACH ROW EXECUTE FUNCTION trap_fn();
+            """)
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_insert_into_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    if not schema.is_writable:
+        pytest.skip("Skipping test for writable schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"INSERT INTO {schema.table_name} ({schema.column}) VALUES ({schema.value});")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_update_in_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    if not schema.is_writable:
+        pytest.skip("Skipping test for writable schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"UPDATE {schema.table_name} SET {schema.column} = {schema.value} WHERE {schema.column} <> {schema.value};")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_delete_from_schema(sql_connection, schema):
+    if schema.table is None:
+        pytest.skip("Skipping test for public schema")
+    if not schema.is_writable:
+        pytest.skip("Skipping test for writable schema")
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"DELETE FROM {schema.table_name} WHERE {schema.column} = {schema.value};")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_grant_privileges(sql_connection, schema):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA {schema.schema} TO PUBLIC;")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_revoke_privileges(sql_connection, schema):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"REVOKE SELECT ON ALL TABLES IN SCHEMA {schema.schema} FROM PUBLIC;")
+
+
+def test_cannot_create_schema(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("CREATE SCHEMA forbidden_schema;")
+
+
+@pytest.mark.parametrize("schema", SCHEMAS)
+def test_cannot_drop_schema(sql_connection, schema):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(f"DROP SCHEMA IF EXISTS {schema.schema};")
+
+
+def test_cannot_create_sequence(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("CREATE SEQUENCE forbidden_seq;")
+
+
+def test_cannot_create_domain(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("CREATE DOMAIN forbidden_domain AS INTEGER;")
+
+
+def test_cannot_create_type(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("CREATE TYPE forbidden_type AS (id INTEGER, name TEXT);")
+
+
+def test_cannot_vacuum(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("VACUUM;")
+
+
+def test_cannot_analyze(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("ANALYZE;")
+
+
+def test_cannot_reindex(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("REINDEX DATABASE aperturedb;")
+
+
+def test_cannot_copy_to_file(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("COPY (SELECT 1) TO '/tmp/forbidden.txt';")
+
+
+def test_cannot_copy_from_file(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("COPY forbidden_table FROM '/tmp/forbidden.txt';")
+
+
+def test_cannot_set_config(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("SET shared_preload_libraries = 'forbidden';")
+
+
+def test_cannot_alter_database(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("ALTER DATABASE aperturedb SET log_statement = 'all';")
+
+
+def test_cannot_alter_user(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("ALTER USER aperturedb PASSWORD 'forbidden';")
+
+
+def test_cannot_create_user(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("CREATE USER forbidden_user;")
+
+
+def test_cannot_drop_user(sql_connection):
+    with sql_connection.cursor() as cur:
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("DROP USER IF EXISTS forbidden_user;")


### PR DESCRIPTION
As a response to the recent security audit, this PR does three things:
* Removes an unrequested feature that the SQL user be able to create and modify tables in the public schema. There is some marginal case for this feature, but we should probably add it (carefully) when actually requested.
* Drops certain PostgreSQL extensions that would allow the server to execute arbitrary code (e.g. printing environment variables).
* Adds a new test suite that attempts to violate various security restrictions.