### PR TITLE
Fix sql-server workflow for 0.18.15 release

### DIFF
--- a/apps/sql-server/app/proxy.py
+++ b/apps/sql-server/app/proxy.py
@@ -30,7 +30,11 @@ async def query_multipart(
     query: str = Form(...),
     blobs: Optional[List[UploadFile]] = File(None),
 ):
-    in_json = json.loads(query)
+    try:
+        in_json = json.loads(query)
+    except Exception as e:
+        logger.error(f"Error parsing JSON: {e} {query=}")
+        raise
     in_blobs = [await b.read() for b in (blobs or [])]
     status, out_json, out_blobs = pool.execute_query(in_json, in_blobs)
     return JSONResponse({

--- a/apps/sql-server/fdw/fdw/aperturedb.py
+++ b/apps/sql-server/fdw/fdw/aperturedb.py
@@ -6,7 +6,6 @@
 
 import json
 import base64
-from locale import CODESET
 import uuid
 from typing import List, Optional, Tuple, Dict, Any, Literal
 import logging

--- a/apps/sql-server/fdw/fdw/aperturedb.py
+++ b/apps/sql-server/fdw/fdw/aperturedb.py
@@ -6,6 +6,7 @@
 
 import json
 import base64
+from locale import CODESET
 import uuid
 from typing import List, Optional, Tuple, Dict, Any, Literal
 import logging
@@ -68,8 +69,13 @@ def execute_query(
             f"HTTP error {resp_status} from ApertureDB proxy: {data.decode('utf-8')}"
         )
 
-    parsed = json.loads(data)
-    out_json = parsed["json"]
+    try:
+        parsed = json.loads(data)
+        out_json = parsed["json"]
+    except Exception as e:
+        logger.error(f"Error parsing JSON: {e} {data=}")
+        raise
+
     out_blobs = [base64.b64decode(s) for s in parsed.get("blobs", [])] or None
     out_status = parsed.get('status', 0)
     elapsed_time = datetime.now() - start_time

--- a/apps/sql-server/fdw/fdw/column.py
+++ b/apps/sql-server/fdw/fdw/column.py
@@ -58,7 +58,11 @@ class ColumnOptions(BaseModel):
         Create a ColumnOptions instance from a string dictionary.
         This is used to decode options from the foreign table column definition.
         """
-        options = json.loads(options_str["column_options"])
+        try:
+            options = json.loads(options_str["column_options"])
+        except Exception as e:
+            logger.error(f"Error parsing JSON: {e} {options_str=}")
+            raise
         return cls(**options)
 
     def to_string(self) -> Dict[str, str]:

--- a/apps/sql-server/fdw/fdw/system.py
+++ b/apps/sql-server/fdw/fdw/system.py
@@ -267,7 +267,7 @@ def get_consistent_properties(type_: Literal["entities", "connections"]) -> List
         # data may be either a dict or a list of dicts
         if isinstance(data, dict):
             data = [data] # normalize to list form
-            
+
         for item in data:
             if "properties" in item and item["properties"] is not None:
                 assert isinstance(item["properties"], dict), \

--- a/apps/sql-server/fdw/fdw/table.py
+++ b/apps/sql-server/fdw/fdw/table.py
@@ -88,9 +88,6 @@ def connection(class_name: Optional[str],
     Queries that are on system classes, or which neither request nor constrain other connection properties
     are converted to a pair of Find<Object> commands using "is_connected_to".
 
-    In the case of connection classes with multiple entries, then src_class and dst_class are None.
-    In this case, we cannot use Find<Object> commands, so we fall back on an unconstrained "FindConnection" command, but only if it is not a system class (https://github.com/aperture-data/athena/issues/1746).
-
     So the input query is a single FindConnection command, and the output has one of these six forms:
     1. Single FindConnection command
     2. A Find<Object> command ref-tied to `src` in FindConnection
@@ -123,11 +120,6 @@ def connection(class_name: Optional[str],
 
     if class_name and not is_system_class:
         command_body["with_class"] = class_name
-
-    # If src_class and dst_class are None, then we fall back on an unconstrained FindConnection command, possibly with `with_class`
-    if src_class is None and dst_class is None:
-        logger.warning(f"Sticking with unconstraied FindConnection: {query=}")
-        return None
 
     result_query = []
 

--- a/apps/sql-server/fdw/fdw/table.py
+++ b/apps/sql-server/fdw/fdw/table.py
@@ -74,7 +74,7 @@ def literal(parameters: Dict[str, Any],
 
 
 def connection(class_name: Optional[str],
-               src_class: str, dst_class: str,
+               src_class: Optional[str], dst_class: Optional[str],
                query: List[dict]) -> Optional[Callable]:
     """
     A TableOptions modify_query hook.
@@ -88,6 +88,9 @@ def connection(class_name: Optional[str],
     Queries that are on system classes, or which neither request nor constrain other connection properties
     are converted to a pair of Find<Object> commands using "is_connected_to".
 
+    In the case of connection classes with multiple entries, then src_class and dst_class are None.
+    In this case, we cannot use Find<Object> commands, so we fall back on an unconstrained "FindConnection" command, but only if it is not a system class (https://github.com/aperture-data/athena/issues/1746).
+
     So the input query is a single FindConnection command, and the output has one of these six forms:
     1. Single FindConnection command
     2. A Find<Object> command ref-tied to `src` in FindConnection
@@ -100,6 +103,7 @@ def connection(class_name: Optional[str],
     because the results will be a dictionary rather than a flat list. This hook optionally returns a function
     that takes the response and returns the rewritten results.
     """
+
     # The three questions we ask are:
     # Is this a system class?
     # Does it request or constrain _src or _dst?
@@ -119,6 +123,11 @@ def connection(class_name: Optional[str],
 
     if class_name and not is_system_class:
         command_body["with_class"] = class_name
+
+    # If src_class and dst_class are None, then we fall back on an unconstrained FindConnection command, possibly with `with_class`
+    if src_class is None and dst_class is None:
+        logger.warning(f"Sticking with unconstraied FindConnection: {query=}")
+        return None
 
     result_query = []
 

--- a/apps/sql-server/test/docker-compose.yml
+++ b/apps/sql-server/test/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       ADB_ENABLE_DEBUG: 1
       ADB_LOG_PATH: "logs"
+      # TEMP: force SSL off
+      ADB_FORCE_SSL: false
 
   # One image for both seed and tests (Python + aperturedb + pytest + psycopg)
   # Use the same image; just change the command.
@@ -40,6 +42,8 @@ services:
       DB_PORT: 55555
       DB_USER: admin
       DB_PASS: admin
+      # TEMP: force SSL off
+      USE_SSL: false
     command: ["python", "/app/seed.py"]
 
   sql-server:

--- a/apps/sql-server/test/docker-compose.yml
+++ b/apps/sql-server/test/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     environment:
       ADB_ENABLE_DEBUG: 1
       ADB_LOG_PATH: "logs"
-      # TEMP: force SSL off
-      ADB_FORCE_SSL: false
 
   # One image for both seed and tests (Python + aperturedb + pytest + psycopg)
   # Use the same image; just change the command.
@@ -42,8 +40,6 @@ services:
       DB_PORT: 55555
       DB_USER: admin
       DB_PASS: admin
-      # TEMP: force SSL off
-      USE_SSL: false
     command: ["python", "/app/seed.py"]
 
   sql-server:

--- a/apps/sql-server/test/seed.py
+++ b/apps/sql-server/test/seed.py
@@ -280,6 +280,12 @@ def load_generic_connection_testdata(client):
     status, _, _ = execute_query(client, query)
     assert status == 0
 
+
+def str_to_bool(s):
+    """Convert a string to a boolean."""
+    return s.lower() in ["true", "1", "yes", "y"]
+
+
 def db_connection():
     """Create a database connection."""
     # Not used in testing, but can be used to seed a different database
@@ -291,8 +297,8 @@ def db_connection():
     DB_PORT = int(os.getenv("DB_PORT", "55555"))
     DB_USER = os.getenv("DB_USER", "admin")
     DB_PASS = os.getenv("DB_PASS", "admin")
-    return Connector(host=DB_HOST, user=DB_USER, port=DB_PORT, password=DB_PASS)
-
+    USE_SSL = str_to_bool(os.getenv("USE_SSL", "true"))
+    return Connector(host=DB_HOST, user=DB_USER, port=DB_PORT, password=DB_PASS, use_ssl=USE_SSL)
 
 
 if __name__ == "__main__":

--- a/apps/sql-server/test/seed.py
+++ b/apps/sql-server/test/seed.py
@@ -230,6 +230,34 @@ def load_blobs_testdata(client):
     status, _, _ = execute_query(client, query, blobs)
     assert status == 0
 
+def load_generic_connection_testdata(client):
+    # See https://github.com/aperture-data/athena/issues/757
+    query = [
+        {
+            "AddEntity": {
+            "_ref": 1,
+            "class": "Person"
+            }
+        },
+        {
+            "AddEntity": {
+            "_ref": 2,
+            "class": "School",
+            "connect": {
+                "ref": 1
+            }
+            }
+        },
+        {
+            "AddEntity": {
+            "_ref": 3,
+            "class": "Sport",
+            "connect": {
+                "ref": 2
+            }
+            }
+        }
+    ]
 
 def db_connection():
     """Create a database connection."""
@@ -254,6 +282,7 @@ if __name__ == "__main__":
     load_text_descriptors_testdata(client)
     load_images_testdata(client)
     load_blobs_testdata(client)
+    load_generic_connection_testdata(client)
     print("Test data loaded successfully.")
 
     _, results, _ = execute_query(client, [{"GetSchema": {}}])

--- a/apps/sql-server/test/seed.py
+++ b/apps/sql-server/test/seed.py
@@ -235,29 +235,50 @@ def load_generic_connection_testdata(client):
     query = [
         {
             "AddEntity": {
-            "_ref": 1,
-            "class": "Person"
+                "_ref": 1,
+                "class": "Person"
             }
         },
         {
             "AddEntity": {
-            "_ref": 2,
-            "class": "School",
-            "connect": {
-                "ref": 1
-            }
+                "_ref": 2,
+                "class": "School",
+                "connect": {
+                    "ref": 1
+                }
             }
         },
         {
             "AddEntity": {
-            "_ref": 3,
-            "class": "Sport",
-            "connect": {
-                "ref": 2
+                "class": "Sport",
+                "connect": {
+                    "ref": 2
+                }
             }
+        },
+        {
+            "AddEntity": {
+                "_ref": 3,
+                "class": "College",
+                "connect": {
+                    "ref": 1,
+                    "class": "ReusedConnection"
+                }
+            }
+        },
+        {
+            "AddEntity": {
+                "class": "Athletics",
+                "connect": {
+                    "ref": 3,
+                    "class": "ReusedConnection"
+                }
             }
         }
     ]
+
+    status, _, _ = execute_query(client, query)
+    assert status == 0
 
 def db_connection():
     """Create a database connection."""

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -217,7 +217,11 @@ def _test_constraints_inner(constraint, sql_connection, constraint_formatter):
         cur.execute(sql2)
         result2 = cur.fetchone()[0]
         if isinstance(result2, str):
-            result2 = json.loads(result2)
+            try:
+                result2 = json.loads(result2)
+            except Exception as e:
+                print(f"Error parsing JSON: {e} {result2=}")
+                raise
         plan2 = result2[0]["Plan"]
 
     rows1 = plan_actual_rows(plan1)
@@ -254,7 +258,11 @@ def sum_rows_removed_by_filter(plan_node: dict) -> int:
 def multicorn_plan(plan_node: dict) -> str:
     """Extract the Multicorn plan from the plan node."""
     if "Multicorn" in plan_node:
-        return json.dumps(json.loads(plan_node["Multicorn"]))
+        try:
+            return json.dumps(json.loads(plan_node["Multicorn"]))
+        except Exception as e:
+            print(f"Error parsing JSON: {e} {plan_node=}")
+            raise
     return None
 
 
@@ -279,6 +287,14 @@ def multicorn_plan(plan_node: dict) -> str:
     ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5),
     ("SELECT * FROM connection.\"_DescriptorConnection\";", 20),
     ("SELECT * FROM connection.\"edge\";", 5),
+    ("SELECT * FROM connection.\"_GenericConnection\";", 7),
+    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src;", 1),
+    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1),
+    ("SELECT * FROM connection.\"_GenericConnection\" AS B JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1),
+    ("SELECT * FROM connection.\"ReusedConnection\";", 2),
+    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src;", 1),
+    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1),
+    ("SELECT * FROM connection.\"ReusedConnection\" AS B JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1),
 ])
 def test_join_query(query, n_results, sql_connection, constraint_formatter):
     """
@@ -298,14 +314,44 @@ def test_join_query(query, n_results, sql_connection, constraint_formatter):
         result) == n_results, f"Expected {n_results} rows, got {len(result)} for query: {query}, {query_aql(query, sql_connection)}"
 
 
+def find_all_fields(obj, fieldname):
+    """
+    Recursively search through a nested structure of dicts and lists,
+    yielding all values found under the given fieldname.
+    """
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == fieldname:
+                yield v
+            # recurse into value
+            yield from find_all_fields(v, fieldname)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from find_all_fields(item, fieldname)
+    # else: primitive value, stop
+
+
 def query_aql(query: str, sql_connection) -> str:
     query = f"EXPLAIN (FORMAT JSON) {query};"
     with sql_connection.cursor() as cur:
         cur.execute(query)
         result1 = cur.fetchone()[0]
     if isinstance(result1, str):
-        result1 = json.loads(result1)
-    plan1 = result1[0]["Plan"]
-    multicorn_plan1 = multicorn_plan(plan1)
-    aql = json.loads(multicorn_plan1).get("aql", "")
-    return aql
+        try:
+            result1 = json.loads(result1)
+        except Exception as e:
+            print(f"Error parsing JSON: {e} {result1=}")
+            raise
+    multicorns = list(find_all_fields(result1, "Multicorn"))
+    aqls = []
+    for multicorn in multicorns:
+        try:
+            data = json.loads(multicorn)
+            if "aql" in data:
+                aqls.append(data["aql"])
+            else:
+                print(f"No aql found in {multicorn=}")
+        except Exception as e:
+            print(f"Error parsing JSON: {e} {multicorn=}")
+            raise
+    return aqls

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -287,14 +287,15 @@ def multicorn_plan(plan_node: dict) -> str:
     ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5),
     ("SELECT * FROM connection.\"_DescriptorConnection\";", 20),
     ("SELECT * FROM connection.\"edge\";", 5),
-    ("SELECT * FROM connection.\"_GenericConnection\";", 7),
-    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src;", 1),
-    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1),
-    ("SELECT * FROM connection.\"_GenericConnection\" AS B JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1),
-    ("SELECT * FROM connection.\"ReusedConnection\";", 2),
-    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src;", 1),
-    ("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1),
-    ("SELECT * FROM connection.\"ReusedConnection\" AS B JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1),
+    # These connection classes have multiple items in the data, so we skip them for now
+    pytest.param("SELECT * FROM connection.\"_GenericConnection\";", 7, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src;", 1, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM connection.\"_GenericConnection\" AS B JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM connection.\"ReusedConnection\";", 2, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src;", 1, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM connection.\"ReusedConnection\" AS B JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
 ])
 def test_join_query(query, n_results, sql_connection, constraint_formatter):
     """

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -273,14 +273,10 @@ def multicorn_plan(plan_node: dict) -> str:
     ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids};", 5),
     ("SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids};", 5),
     ("SELECT edge_key FROM \"edge\" WHERE _dst IN {dst_unique_ids};", 5),
-    pytest.param("SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5,
-                  marks=pytest.mark.xfail(
-                      reason="https://github.com/aperture-data/athena/issues/1737")),
+    ("SELECT edge_key FROM \"edge\" WHERE _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5),
     ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids};", 5),
     ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _dst IN {dst_unique_ids};", 5),
-    pytest.param("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5,
-                 marks=pytest.mark.xfail(
-                     reason="https://github.com/aperture-data/athena/issues/1737")),
+    ("SELECT edge_key FROM \"edge\" WHERE _uniqueid in {edge_unique_ids} AND _src IN {src_unique_ids} AND _dst IN {dst_unique_ids};", 5),
     ("SELECT * FROM connection.\"_DescriptorConnection\";", 20),
     ("SELECT * FROM connection.\"edge\";", 5),
 ])

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -356,4 +356,4 @@ def query_aql(query: str, sql_connection) -> str:
         except Exception as e:
             print(f"Error parsing JSON: {e} {multicorn=}")
             raise
-    return aqls
+    return json.dumps(aqls)

--- a/apps/sql-server/test/test_constraints.py
+++ b/apps/sql-server/test/test_constraints.py
@@ -265,6 +265,7 @@ def multicorn_plan(plan_node: dict) -> str:
             raise
     return None
 
+xfail_multiple_items_for_connection_class = pytest.mark.xfail(reason="This connection class has multiple items in the data, so we skip them for now")
 
 @pytest.mark.parametrize("query,n_results", [
     ("SELECT source_key FROM \"SourceNode\";", 5),
@@ -288,14 +289,14 @@ def multicorn_plan(plan_node: dict) -> str:
     ("SELECT * FROM connection.\"_DescriptorConnection\";", 20),
     ("SELECT * FROM connection.\"edge\";", 5),
     # These connection classes have multiple items in the data, so we skip them for now
-    pytest.param("SELECT * FROM connection.\"_GenericConnection\";", 7, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src;", 1, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM connection.\"_GenericConnection\" AS B JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="GenericConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM connection.\"ReusedConnection\";", 2, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src;", 1, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
-    pytest.param("SELECT * FROM connection.\"ReusedConnection\" AS B JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1, marks=pytest.mark.xfail(reason="ReusedConnection has multiple items in the data, so we skip them for now")),
+    pytest.param("SELECT * FROM connection.\"_GenericConnection\";", 7, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src;", 1, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"_GenericConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM connection.\"_GenericConnection\" AS B JOIN entity.\"School\" AS C ON B._dst = C._uniqueid;", 1, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM connection.\"ReusedConnection\";", 2, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src;", 1, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM entity.\"Person\" AS A JOIN connection.\"ReusedConnection\" AS B ON A._uniqueid = B._src JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1, marks=xfail_multiple_items_for_connection_class),
+    pytest.param("SELECT * FROM connection.\"ReusedConnection\" AS B JOIN entity.\"College\" AS C ON B._dst = C._uniqueid;", 1, marks=xfail_multiple_items_for_connection_class),
 ])
 def test_join_query(query, n_results, sql_connection, constraint_formatter):
     """


### PR DESCRIPTION
This PR includes fixes sql-server for the recent 0.18.15 release of ApertureDB. In particular:
* https://github.com/aperture-data/athena/pull/1726 where GetSchema now returns lists of dicts instead of dicts for connection classes
* https://github.com/aperture-data/athena/issues/757 which fixes two "XFAIL' test  cases

NOTE: This is part one of a two-part fix. In this part, connection classes with more than one schema entry are simply dropped. This gets things working at the expense of not handling a fairly rare circumstance. Part two will make these connection classes work (details TBD).