### PR TITLE
Fix MCP server for list-valued connection classes

### DIFF
--- a/apps/ingest-croissant/test.sh
+++ b/apps/ingest-croissant/test.sh
@@ -28,7 +28,7 @@ docker run -d \
            --health-retries=20 \
            --health-interval=1s \
            aperturedata/aperturedb-community
-docker exec ${DB_NAME} apt-get install -y netcat
+docker exec ${DB_NAME} apt-get install -y netcat-traditional
 
 echo "Waiting for the ${DB_NAME} to be ready..."
 until [ "`docker inspect -f {{.State.Health.Status}} ${DB_NAME}`" == "healthy" ]; do

--- a/apps/ingest-from-bucket/test.sh
+++ b/apps/ingest-from-bucket/test.sh
@@ -59,7 +59,7 @@ docker run -d \
            --health-retries=20 \
            --health-interval=1s \
            aperturedata/aperturedb-community
-docker exec ${DB_NAME} apt-get install -y netcat
+docker exec ${DB_NAME} apt-get install -y netcat-traditional
 
 echo "Waiting for the ${DB_NAME} to be ready..."
 until [ "`docker inspect -f {{.State.Health.Status}} ${DB_NAME}`" == "healthy" ]; do

--- a/apps/mcp-server/app/app.py
+++ b/apps/mcp-server/app/app.py
@@ -20,7 +20,7 @@ def test_connection():
     client = create_connector()
     from aperturedb.Utils import Utils
     utils = Utils(client)
-    utils.summary()
+    utils.get_schema()
 
 
 test_connection()

--- a/apps/mcp-server/app/tools/schema.py
+++ b/apps/mcp-server/app/tools/schema.py
@@ -1,11 +1,37 @@
 import os
-from typing import List, Annotated
+from typing import List, Annotated, Optional, Dict
 
 from pydantic import BaseModel, Field
 
 from shared import logger, connection_pool
 from decorators import declare_mcp_tool
 from aperturedb.Utils import Utils
+
+
+class ClassList(BaseModel):
+    classes: List[str]
+
+
+class PropertyDescription(BaseModel):
+    matched: int
+    indexed: bool
+    type: str
+
+
+class EntityClassDescription(BaseModel):
+    matched: int
+    properties: Dict[str, PropertyDescription]
+
+
+class ConnectionClassDescription(BaseModel):
+    matched: int
+    properties: Dict[str, PropertyDescription]
+    src: str
+    dst: str
+
+
+class ConnectionClassDescriptions(BaseModel):
+    items: List[ConnectionClassDescription]
 
 
 def get_schema():
@@ -16,8 +42,9 @@ def get_schema():
     return schema
 
 
+
 @declare_mcp_tool
-def list_entity_classes() -> List[str]:
+def list_entity_classes() -> ClassList:
     """List all entity classes in the database."""
     schema = get_schema()
     try:
@@ -25,14 +52,14 @@ def list_entity_classes() -> List[str]:
     except KeyError:
         logger.error("Schema does not contain 'entities' or 'classes'.")
         raise ValueError("Schema does not contain 'entities' or 'classes'.")
-    return list(results)
+    return ClassList(classes=list(results))
 
 
 @declare_mcp_tool
 def describe_entity_class(
     class_name: Annotated[str, Field(
         description="The name of the entity class to describe")]
-) -> dict:
+) -> EntityClassDescription:
     """Describe an entity class in the database."""
     schema = get_schema()
     try:
@@ -40,11 +67,11 @@ def describe_entity_class(
     except KeyError:
         logger.error(f"Entity class '{class_name}' not found in schema.")
         raise ValueError(f"Entity class '{class_name}' not found in schema.")
-    return description
+    return EntityClassDescription(matched=description['matched'], properties={k: PropertyDescription(matched=v[0], indexed=v[1], type=v[2]) for k, v in (description.get('properties') or {}).items()})
 
 
 @declare_mcp_tool
-def list_connection_classes() -> List[str]:
+def list_connection_classes() -> ClassList:
     """List all connection classes in the database."""
     schema = get_schema()
     try:
@@ -52,20 +79,24 @@ def list_connection_classes() -> List[str]:
     except KeyError:
         logger.error("Schema does not contain 'connections' or 'classes'.")
         raise ValueError("Schema does not contain 'connections' or 'classes'.")
-    return list(results)
+    return ClassList(classes=list(results))
 
 
 @declare_mcp_tool
 def describe_connection_class(
     class_name: Annotated[str, Field(
         description="The name of the connection class to describe")]
-) -> dict:
+) -> ConnectionClassDescriptions:
     """Describe an connection class in the database."""
     schema = get_schema()
     try:
+        # From athena 0.18.15, connection class values are lists of dicts
+        # so we standardize on that format
         description = schema['connections']['classes'][class_name]
+        if isinstance(description, dict):
+            description = [description]
     except KeyError:
         logger.error(f"Connection class '{class_name}' not found in schema.")
         raise ValueError(
             f"Connection class '{class_name}' not found in schema.")
-    return description
+    return ConnectionClassDescriptions(items=[ConnectionClassDescription(matched=d['matched'], properties={k: PropertyDescription(matched=v[0], indexed=v[1], type=v[2]) for k, v in (d.get('properties') or {}).items()}, src=d['src'], dst=d['dst']) for d in description])

--- a/apps/rag/test.sh
+++ b/apps/rag/test.sh
@@ -56,7 +56,7 @@ function setup() {
 
     docker build -t get_summary -f- . <<EOD
 FROM aperturedata/workflows-base
-RUN echo "/opt/venv/bin/adb utils execute summary" > /app/app.sh
+RUN echo "python3 -c 'from aperturedb.CommonLibrary import create_connector; client = create_connector(); from aperturedb.Utils import Utils; utils = Utils(client); import json; print(json.dumps(utils.get_schema(), indent=4))'" > /app/app.sh
 EOD
 }
 


### PR DESCRIPTION
This PR updates the MCP server to accommodate the recent change to GetSchema format.
It also improves the way we declare the result types of schema tools.

I also switched from `netcat` to `netcat-traditional` to accomodate Ubuntu 24 runners.
I also remove some dependencies on "summary".