### PR TITLE
Restrict access for POST methods on status server

### DIFF
--- a/base/docker/scripts/status_server.py
+++ b/base/docker/scripts/status_server.py
@@ -16,10 +16,15 @@ lock = threading.Lock()
 def is_localhost_request(request: Request) -> bool:
     """
     Check if the request is coming from localhost.
+
+    If the client host is None (e.g., request.client is None), access is denied (returns False).
     """
     client_host = request.client.host if request.client else None
     # Check for common localhost addresses
     localhost_addresses = {'127.0.0.1', '::1', 'localhost'}
+    if client_host is None:
+        # Explicitly deny access if client_host is None
+        return False
     return client_host in localhost_addresses
 
 


### PR DESCRIPTION
APD-02-019 WP2: Updating workflows’ status service without authorization (Low)

Alternatives:

- [x] Remove POST methods. Discarded.
  - [ ] [Does not work because workflows rely](https://github.com/aperture-data/workflows/pull/217#issuecomment-3377537840) on POST method to update status.
  - [ ] Proposed solution by @ali-asadpoor : Use filesystem instead of REST calls for managing status.
  
- [ ] Introduce authentication for workflows status server
    - [ ] Require multiple changes on workflows, infra, and cloud

- [x] Restrict access for POST methods to localhost (**this PR**)

    ## Changes Made:
    1. Added HTTPException import: Added HTTPException to the FastAPI imports to handle access denial responses.
    
    2. Created localhost validation function: Added a helper function `is_localhost_request()` that checks if the incoming request is from localhost by verifying the client IP address against common localhost addresses (127.0.0.1, ::1, localhost).
    
    3. Modified `/reconfigure` POST endpoint: Added localhost validation that returns a 403 Forbidden error if the request doesn't come from localhost.
    
    4. Modified `/response` POST endpoint: Added the same localhost validation to prevent external access.
    
    ## Security Benefits:
    * Access Control: Both POST endpoints now only accept requests from localhost (127.0.0.1, ::1, or localhost)
    * Error Handling: Non-localhost requests receive a clear 403 Forbidden response with an appropriate error message
    * Documentation: Updated the docstrings to indicate the localhost-only restriction
    
    The GET endpoint (`/status`) remains accessible from any source since it's read-only and doesn't modify the application state. This provides a good balance between security and functionality, allowing external monitoring while protecting critical configuration and data modification endpoints.
    
