### PR TITLE
ci: add --fail to curl commands to prevent silent failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          curl -s -H "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
+          curl -f -s -H "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
                 -H "Accept: application/vnd.github+json" \
                 -X POST \
                 https://api.github.com/repos/${{ github.repository }}/commits/$SHA/comments \
@@ -260,7 +260,7 @@ jobs:
         run: |
           set -euo pipefail
           SHA="${{ github.sha }}"
-          COMMIT_MSG=$(curl -s -H "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
+          COMMIT_MSG=$(curl -f -s -H "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
           https://api.github.com/repos/${{ github.repository }}/commits/$SHA | jq -r .commit.message)
           PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)
           if [ -n "$PR_NUMBER" ]; then
@@ -280,7 +280,7 @@ jobs:
             body: "Docker images for version \($ver) were built and pushed after this PR was merged.  [View workflow run](\($run_url))"
           }')
 
-          curl -s -X POST \
+          curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.PAT_VARIABLES }}" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments \
@@ -288,7 +288,7 @@ jobs:
 
       - name: Update version on infra develop
         run: |
-          curl -X POST \
+          curl -f -s -X POST \
           -H "Authorization: token ${{ secrets.PAT_INFRA }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/aperture-data/infra/dispatches \


### PR DESCRIPTION
This fixes an issue in the `update-version` job where `curl` was failing silently with an HTTP 404 (likely due to a missing/invalid `PAT_INFRA` or `PAT_VARIABLES` secret on the private repo) but exiting with code 0. Adding `-f` (and `-s`) makes these failures loud so the Action properly marks the run as failed.