### PR TITLE
ci: fix infra dispatch auth header format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Update version on infra develop
         run: |
           curl -f -s -X POST \
-          -H "Authorization: token ${{ secrets.PAT_INFRA }}" \
+          -H "Authorization: Bearer ${{ secrets.PAT_INFRA }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/aperture-data/infra/dispatches \
           -d "{\"event_type\": \"update-tag\", \"client_payload\": {\"environment\":\"develop\", \"component\": \"workflows-public\", \"tag\": \"${VERSION}\"}}"


### PR DESCRIPTION
The `update-version` job is failing to trigger the `infra` dispatch with a 401/404 error because it uses `-H "Authorization: token ${{ secrets.PAT_INFRA }}"` instead of `-H "Authorization: Bearer ${{ secrets.PAT_INFRA }}"`. For standard fine-grained PATs / modern GitHub API tokens, `Bearer` should be used (or the auth fails and it defaults to anonymous access, generating a 404 for the private `infra` repo).