### PR TITLE
chore: update aperturedb package to 0.4.58

### DIFF
--- a/apps/dataset-ingestion-movies/test/requirements.txt
+++ b/apps/dataset-ingestion-movies/test/requirements.txt
@@ -1,2 +1,2 @@
 pytest
-aperturedb
+aperturedb==0.4.58

--- a/apps/embeddings-extraction/test/requirements.txt
+++ b/apps/embeddings-extraction/test/requirements.txt
@@ -1,4 +1,4 @@
-aperturedb
+aperturedb==0.4.58
 nltk
 pytest
 pandas

--- a/apps/ingest-from-bucket/tests/checker/Dockerfile
+++ b/apps/ingest-from-bucket/tests/checker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
 
 
 RUN pip3 install --upgrade pip && \
-    pip3 install aperturedb
+    pip3 install aperturedb==0.4.58
 
 
 

--- a/apps/mcp-server/test/requirements.txt
+++ b/apps/mcp-server/test/requirements.txt
@@ -1,4 +1,4 @@
-aperturedb
+aperturedb==0.4.58
 pytest
 pytest-asyncio
 fastmcp

--- a/apps/ocr-extraction/test/requirements.txt
+++ b/apps/ocr-extraction/test/requirements.txt
@@ -1,4 +1,4 @@
-aperturedb
+aperturedb==0.4.58
 nltk
 pytest
 pandas

--- a/apps/sql-server/test/requirements.txt
+++ b/apps/sql-server/test/requirements.txt
@@ -1,3 +1,3 @@
-aperturedb
+aperturedb==0.4.58
 psycopg2-binary
 pytest

--- a/base/docker/requirements.txt
+++ b/base/docker/requirements.txt
@@ -5,4 +5,4 @@ fastapi
 uvicorn
 typer
 prometheus_client
-aperturedb
+aperturedb==0.4.58


### PR DESCRIPTION
This PR pins the `aperturedb` python package to the latest version `0.4.58` across all apps.