### PR TITLE
fix: Labelstudio workflow does not connect to ApertureDB

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,9 +185,6 @@ jobs:
       VERSION: ${{ needs.get-version.outputs.version }}
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,9 @@ jobs:
       VERSION: ${{ needs.get-version.outputs.version }}
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/apps/label-studio/app/label_studio.py
+++ b/apps/label-studio/app/label_studio.py
@@ -75,6 +75,7 @@ def main(args):
     set_state(LabelStudioPhase.SETUP,completeness=0)
     def add_common_vars( env ):
 
+        env["LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS"]="aperturedb,gcs,s3"
         env["LABEL_STUDIO_DEBUG"]="FALSE" 
         env["LABEL_STUDIO_APERTUREDB_KEY"]=db.config.deflate()
         env["LABEL_STUDIO_APERTUREDB_UNTAGGED_IMAGES"]= "TRUE" if args.label_studio_handle_untagged else "FALSE"

--- a/apps/label-studio/app/label_studio.py
+++ b/apps/label-studio/app/label_studio.py
@@ -167,7 +167,6 @@ def main(args):
         ls_env["WORKFLOW_NAME"]="label-studio"
         ls_env["WORKFLOW_SPEC_ID"]=args.spec_id 
         ls_env["WORKFLOW_RUN_ID"]=str(run_id)
-        logger.error(f" ENV FOR MAIN IS: {ls_env}")
 
         logger.info("Preparing to start Label Studio.")
         set_state(LabelStudioPhase.SERVING,completeness=70)

--- a/apps/label-studio/app/label_studio.py
+++ b/apps/label-studio/app/label_studio.py
@@ -121,6 +121,7 @@ def main(args):
             env["LABEL_STUDIO_APERTUREDB_DEFAULT_LIMIT"] = str(args.label_studio_default_storage_limit)
         env["LABEL_STUDIO_APERTUREDB_RO_PREDS"] = str(args.label_studio_storage_annotations_ro)
         env["LABEL_STUDIO_APERTUREDB_DEFAULT_LOAD_PREDS"] = str(args.label_studio_default_import_annotations)
+        env["LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS"] = "aperturedb,gcs,s3"
 
 
     logger.info("Preparing for Label Studio configuration.")
@@ -166,7 +167,6 @@ def main(args):
         ls_env["WORKFLOW_NAME"]="label-studio"
         ls_env["WORKFLOW_SPEC_ID"]=args.spec_id 
         ls_env["WORKFLOW_RUN_ID"]=str(run_id)
-        ls_env["LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS"]="aperturedb,gcs,s3" 
         logger.error(f" ENV FOR MAIN IS: {ls_env}")
 
         logger.info("Preparing to start Label Studio.")

--- a/apps/label-studio/app/label_studio.py
+++ b/apps/label-studio/app/label_studio.py
@@ -122,7 +122,6 @@ def main(args):
             env["LABEL_STUDIO_APERTUREDB_DEFAULT_LIMIT"] = str(args.label_studio_default_storage_limit)
         env["LABEL_STUDIO_APERTUREDB_RO_PREDS"] = str(args.label_studio_storage_annotations_ro)
         env["LABEL_STUDIO_APERTUREDB_DEFAULT_LOAD_PREDS"] = str(args.label_studio_default_import_annotations)
-        env["LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS"] = "aperturedb,gcs,s3"
 
 
     logger.info("Preparing for Label Studio configuration.")

--- a/apps/label-studio/app/label_studio.py
+++ b/apps/label-studio/app/label_studio.py
@@ -110,7 +110,7 @@ def main(args):
             # strip trailing /
             if subpath[-1:] == '/':
                 logger.debug("Subpath had trailing slash, stripped.") 
-                subpath = sub_path[:-1]
+                subpath = subpath[:-1]
 
             logger.debug(f"Path is {full_path} and {subpath}")
             
@@ -166,7 +166,7 @@ def main(args):
         ls_env["WORKFLOW_NAME"]="label-studio"
         ls_env["WORKFLOW_SPEC_ID"]=args.spec_id 
         ls_env["WORKFLOW_RUN_ID"]=str(run_id)
-        ls_env["LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS"]="aperturedb gcs s3" 
+        ls_env["LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS"]="aperturedb,gcs,s3" 
         logger.error(f" ENV FOR MAIN IS: {ls_env}")
 
         logger.info("Preparing to start Label Studio.")


### PR DESCRIPTION
## Summary

Fixes #247 by correcting the format of `LABEL_STUDIO_CONFIGURED_STORAGE_BACKENDS` (from space-separated to comma-separated) and fixing a `NameError` due to a typo (`sub_path` vs `subpath`).

## Changes

- Replaced `"aperturedb gcs s3"` with `"aperturedb,gcs,s3"` for storage backends.
- Fixed a typo where `sub_path` was used instead of `subpath` when stripping trailing slashes.

## Testing

Tested that the variables are formatted correctly to allow Label Studio to initialize ApertureDB backend.

Fixes aperture-data/workflows#247