### PR TITLE
fix: investigate and fix CelebA ingestion issues

### DIFF
--- a/apps/dataset-ingestion/app/build_faces/CelebA.py
+++ b/apps/dataset-ingestion/app/build_faces/CelebA.py
@@ -46,8 +46,8 @@ class CelebA(Subscriptable):
         df = pd.DataFrame(self.collection)
 
         df ['filename'] = df['image_id'].apply(lambda x: os.path.join(self.images_align_root, x))
-        df ['image_id'] = df['image_id'].apply(lambda x: f"cropped_{os.path.splitext(x)[0]}")
         df ['constraint_image_id'] = df['image_id']
+        df ['image_id'] = df['image_id'].apply(lambda x: f"cropped_{os.path.splitext(x)[0]}")
         cols = df.columns.tolist()
         cols.remove('filename')
         cols.insert(0, 'filename')


### PR DESCRIPTION
Closes #63

This PR fixes the column order bug during CelebA ingestion. It ensures `constraint_image_id` is set appropriately based on `image_id` and addresses the ingestion failure.