### PR TITLE
feat: Add vectordb-compare app and fix benchmark measurement discrepancies

### DIFF
--- a/apps/vectordb-compare/.dockerignore
+++ b/apps/vectordb-compare/.dockerignore
@@ -1,0 +1,9 @@
+app/input/
+app/output/
+app/ann-benchmarks/
+app/__pycache__/
+app/.venv/
+
+input/
+output/
+*.log

--- a/apps/vectordb-compare/.env.sample
+++ b/apps/vectordb-compare/.env.sample
@@ -1,0 +1,35 @@
+# Benchmark configuration
+
+CONCURRENCIES="1,4,16,32,64"
+ENGINES="adb,qd,ldb,pc"
+KEEP_PREV_OUTPUT="false"
+POST_TO_SLACK="true"
+PUSH_TO_S3="true"
+RUN_NAME="local_run"
+DATASET="deepimage96"
+SIZES="1000,10000,100000,1000000"
+STATS_PERCENTILE="90"
+
+APERTUREDB_KEY="your-aperturedb-key-here"
+
+# Pinecone configuration
+PINECONE_API_KEY="your-pinecone-api-key-here"
+
+# Weaviate configuration
+WEAVIATE_CLUSTER_URL="your-cluster-url.c0.us-east1.gcp.weaviate.cloud"
+WEAVIATE_API_KEY="your-weaviate-api-key-here"
+
+# Qdrant configuration
+QDRANT_CLUSTER_URL="https://your-cluster-url.us-east4-0.gcp.cloud.qdrant.io"
+QDRANT_API_KEY="your-qdrant-api-key-here"
+
+LANCEDB_URI="db://cluster-url"
+LANCEDB_API_KEY="your-lancedb-api-key-here"
+
+# AWS credentials (set these in your environment or uncomment and fill)
+# This is to upload results to benchmarking S3 bucket
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+
+# Slack configuration
+SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}

--- a/apps/vectordb-compare/Dockerfile
+++ b/apps/vectordb-compare/Dockerfile
@@ -1,0 +1,15 @@
+FROM aperturedata/wf-base
+
+# Do not remove this.
+# This env variable is needed to correctly
+# upload results to S3 buckets.
+# It is set by build.sh
+ARG APP_NAME
+ENV APP_NAME=${APP_NAME}
+
+# Start adding specifics for your wf here:
+
+COPY requirements.txt /
+RUN pip install --no-cache-dir -r /requirements.txt
+
+COPY app/ /app/

--- a/apps/vectordb-compare/README.md
+++ b/apps/vectordb-compare/README.md
@@ -1,0 +1,436 @@
+# Vector Database Benchmark Comparison
+
+A comprehensive benchmark workflow that compares the performance of vector database engines: **ApertureDB**, **Pinecone**, **Weaviate**, **Qdrant**, and **LanceDB**.
+
+## Overview
+
+This benchmark provides a cVerifying deepimage96_1k with k=10...
+  ✓ adb: Recall@10=0.892, Precision@10=0.892 (100 queries, 0.045s)
+  ✓ pc: Recall@10=0.874, Precision@10=0.874 (100 queries, 0.038s)
+  ✓ wv: Recall@10=0.901, Precision@10=0.901 (100 queries, 0.052s)
+
+================================================================================
+VERIFICATION TIMING ANALYSIS
+================================================================================
+Configuration             Engine     Load (s)   Calc (s)   Total (s)  File Size
+--------------------------------------------------------------------------------
+deepimage96_1k_k10        adb        0.023      0.022      0.045      12.3KB
+                          pc         0.019      0.019      0.038      11.8KB
+                          wv         0.031      0.021      0.052      13.1KB
+
+--------------------------------------------------
+TIMING SUMMARY
+--------------------------------------------------
+Engine     Avg Time (s)    Min Time (s)    Max Time (s)
+--------------------------------------------------
+adb        0.045          0.045          0.045
+pc         0.038          0.038          0.038
+wv         0.052          0.052          0.052
+
+✅ All engines show good accuracy (>70% recall and precision)e pipeline for:
+- **Data Ingestion** - Load vector datasets into multiple databases
+- **Verification** - Validate that data was ingested correctly
+- **KNN Benchmarking** - Compare search performance across engines
+
+### Supported Vector Databases
+
+| Engine | Code | Description |
+|--------|------|-------------|
+| **ApertureDB** | `adb` | High-performance multimodal database |
+| **Pinecone** | `pc` | Vector database as a service |
+| **Weaviate** | `wv` | Open-source vector search engine |
+| **Qdrant** | `qd` | High-performance vector similarity engine |
+| **LanceDB** | `ldb` | Serverless vector database built on Lance format |
+
+### Datasets
+
+- **`deepimage96`** - Deep learning image features (96 dimensions)
+- **`yfcc100m`** - YFCC100M dataset features (4096 dimensions)
+
+## Architecture
+
+The benchmark uses a **modular architecture** with dynamic loading:
+
+### Core Components
+
+- **`ingest.py`** - Data ingestion pipeline with engine selection
+- **`verify_ingestion.py`** - Verify data was loaded correctly
+- **`knn.py`** - KNN performance benchmarking
+- **`utils.py`** - Shared utilities with dynamic imports
+
+### Engine-Specific Modules
+
+Each database engine is implemented in separate modules with isolated imports:
+
+```
+├── ingest_aperturedb.py     # ApertureDB ingestion
+├── ingest_pinecone.py       # Pinecone ingestion
+├── ingest_weaviate.py       # Weaviate ingestion
+├── ingest_qdrant.py         # Qdrant ingestion
+├── ingest_lancedb.py        # LanceDB ingestion
+├── knn_aperturedb.py        # ApertureDB KNN
+├── knn_pinecone.py          # Pinecone KNN
+├── knn_weaviate.py          # Weaviate KNN
+├── knn_qdrant.py            # Qdrant KNN
+├── knn_lancedb.py           # LanceDB KNN
+├── verify_aperturedb.py     # ApertureDB verification
+├── verify_pinecone.py       # Pinecone verification
+├── verify_weaviate.py       # Weaviate verification
+├── verify_qdrant.py         # Qdrant verification
+└── verify_lancedb.py        # LanceDB verification
+```### Key Features
+
+#### 🔧 **Engine Selection**
+Run benchmarks on specific engines using the `-engines` flag:
+
+```bash
+# Run all engines
+python knn.py -engines "adb,pc,wv,qd,ldb"
+
+# Run only ApertureDB and Pinecone
+python knn.py -engines "adb,pc"
+
+# Run single engine
+python knn.py -engines "adb"
+```
+
+#### 🛡️ **Graceful Degradation**
+Missing dependencies don't crash the entire benchmark:
+
+```
+Failed to import engine pc: No module named 'pinecone'
+Skipping pc - required dependencies not available
+✓ ADB ingestion completed
+✓ QD ingestion completed
+```
+
+#### 📦 **Import Isolation**
+Engine dependencies are only imported when used, preventing conflicts.
+
+#### 🔄 **Docker Compose Support**
+Easy deployment with environment-based configuration.
+
+## Quick Start
+
+### Using Docker Compose
+
+1. **Set up environment**:
+```bash
+cp .env.example .env
+# Edit .env with your credentials
+```
+
+2. **Run the benchmark**:
+```bash
+docker compose up --build
+```
+
+### Manual Usage
+
+1. **Data Ingestion**:
+```bash
+python ingest.py -engines "adb,pc,wv,qd,ldb" -source "deepimage96"
+```
+
+2. **Verify Ingestion**:
+```bash
+python verify_ingestion.py -engines "adb,pc,wv,qd,ldb" -source "deepimage96"
+```
+
+3. **Run KNN Benchmark**:
+```bash
+python knn.py -engines "adb,pc,wv,qd,ldb" -dataset "deepimage96"
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ENGINES` | Comma-separated engine list | `"adb,pc,wv,qd,ldb"` |
+| `SOURCE` | Dataset source | `"deepimage96"` |
+| `MINIMAL` | Run minimal test (1k vectors) | `false` |
+| `TOTAL_QUERIES` | Number of KNN queries | `100` |
+| `KNN_SAMPLES` | K-nearest neighbors | `10` |
+| `CONCURRENCIES` | Thread counts to test | `"16,32,64"` |
+| `LOAD_BATCH_SIZE` | Ingestion batch size | `1000` |
+| `LOAD_NUM_THREADS` | Ingestion threads | `32` |
+
+### Database Credentials
+
+**ApertureDB**:
+```bash
+DB_HOST=your-aperturedb-host
+DB_PASS=your-password
+```
+
+**Pinecone**:
+```bash
+PINECONE_API_KEY=your-api-key
+```
+
+**Weaviate**:
+```bash
+WEAVIATE_CLUSTER_URL=https://your-cluster.weaviate.cloud
+WEAVIATE_API_KEY=your-api-key
+```
+
+**Qdrant**:
+```bash
+QDRANT_CLUSTER_URL=https://your-cluster.qdrant.io:6333
+QDRANT_API_KEY=your-api-key
+```
+
+**LanceDB**:
+```bash
+LANCEDB_URI=./lancedb
+LANCEDB_API_KEY=your-api-key  # Optional for cloud
+```
+
+## Benchmark Methodology
+
+### 1. Data Ingestion
+- Load vector datasets into each database
+- Use appropriate indexing (HNSW for most engines)
+- Batch processing for optimal performance
+- Progress tracking and timing
+
+### 2. Verification
+- Verify correct number of vectors ingested
+- Check data accessibility across all size tiers
+- Report any discrepancies
+
+### 3. KNN Performance Testing
+- Run K-nearest neighbor searches
+- Test multiple concurrency levels
+- Measure response times and throughput
+- Generate performance statistics
+
+### 4. Results Analysis
+- Export results to CSV format
+- Generate performance percentiles
+- Compare engines across metrics
+- Optional S3 upload and Slack notifications
+
+## Results and Outputs
+
+### Performance Metrics
+- **Response Time**: P50, P90, P95, P99 percentiles
+- **Throughput**: Queries per second at different concurrencies
+- **Accuracy**: KNN result verification
+- **Scalability**: Performance across data sizes (1K, 10K, 100K, 1M)
+
+### Output Files
+- `output/knn_comp.csv` - Benchmark results
+- `output/results_*.txt` - Detailed result sets
+- `output/knn_verification_report.json` - Ground truth verification report
+- Performance logs and timing data
+
+## KNN Result Verification
+
+The benchmark includes **automatic result verification** against ground truth data to ensure accuracy and quality of KNN search results.
+
+### 🎯 **Ground Truth Verification**
+
+After each KNN benchmark run, the system automatically:
+
+1. **Loads ground truth data** from the dataset's `.neighbors` and `.distances` arrays
+2. **Compares each engine's results** against the true nearest neighbors
+3. **Calculates accuracy metrics** for each engine and configuration
+4. **Generates comprehensive reports** with detailed analysis
+
+### 📊 **Accuracy Metrics**
+
+For each engine, the verification calculates:
+
+- **Recall@k**: Percentage of ground truth neighbors found in top-k results
+  ```
+  Recall@k = |intersection(predicted_k, true_k)| / k
+  ```
+
+- **Precision@k**: Percentage of predicted neighbors that are actually correct
+  ```
+  Precision@k = |intersection(predicted_k, true_neighbors)| / |predicted_k|
+  ```
+
+### 🔍 **Verification Process**
+
+```bash
+# KNN benchmark automatically includes verification
+python knn.py -engines "adb,pc,wv" -knn_samples 10
+
+# Example output:
+Loading ground truth data...
+Ground truth loaded: 10000 queries with 100 neighbors each
+
+================================================================================
+KNN RESULTS VERIFICATION AGAINST GROUND TRUTH
+================================================================================
+
+Verifying deepimage96_1k with k=10...
+  ✓ adb: Recall@10=0.892, Precision@10=0.892 (100 queries)
+  ✓ pc: Recall@10=0.874, Precision@10=0.874 (100 queries)
+  ✓ wv: Recall@10=0.901, Precision@10=0.901 (100 queries)
+
+✅ All engines show good accuracy (>70% recall and precision)
+```
+
+### 📋 **Verification Report**
+
+The system generates `output/knn_verification_report.json` containing:
+
+```json
+{
+  "summary": {
+    "total_engine_configs": 3,
+    "avg_recall_across_all": 0.889,
+    "avg_precision_across_all": 0.889,
+    "avg_load_time": 0.024,
+    "avg_calc_time": 0.021,
+    "avg_total_time": 0.045,
+    "accuracy_issues": 0,
+    "sanity_issues": 0
+  },
+  "detailed": {
+    "deepimage96_1k_k10": {
+      "adb": {
+        "recall_at_k": 0.892,
+        "precision_at_k": 0.892,
+        "num_queries": 100,
+        "load_time": 0.023,
+        "calc_time": 0.022,
+        "total_time": 0.045,
+        "individual_recalls": [...],
+        "individual_precisions": [...]
+      }
+    }
+  },
+  "timing": {
+    "ground_truth_load_time": 1.234,
+    "engine_processing": {
+      "deepimage96_1k_k10": {
+        "adb": {
+          "load_time": 0.023,
+          "calc_time": 0.022,
+          "total_time": 0.045,
+          "file_size_bytes": 12589
+        }
+      }
+    }
+  }
+}
+```
+
+### ✅ **Quality Checks**
+
+The verification performs multiple quality checks:
+
+#### **Ground Truth Validation**
+- Compares predicted neighbors against true nearest neighbors
+- Flags engines with recall < 70% or precision < 70%
+- Provides per-query accuracy breakdown
+
+#### **Sanity Checks**
+- Verifies each query returns exactly `k` results
+- Checks for duplicate neighbors in results
+- Validates neighbor IDs are valid integers
+
+#### **Cross-Engine Analysis**
+- Compares performance across all engines
+- Identifies outliers or problematic configurations
+- Provides engine ranking by accuracy
+
+#### **Verification Timing Analysis**
+- Measures time to load result files for each engine
+- Tracks calculation time for accuracy metrics
+- Shows file sizes and processing efficiency
+- Provides timing summaries across engines and configurations
+- Helps identify performance bottlenecks in verification process
+
+### 🛠️ **Testing the Verification**
+
+You can test the verification system independently:
+
+```bash
+# Run verification test with mock data
+python test_verification.py
+```
+
+This creates mock result files with different accuracy levels and verifies the system correctly identifies good vs poor results.
+
+## Advanced Usage
+
+### Custom Configurations
+
+```bash
+# Minimal test with single engine
+python knn.py -engines "adb" -minimal true -total_queries 10
+
+# High-throughput test
+python knn.py -engines "adb,pc" -concurrencies "32,64,128" -total_queries 1000
+
+# Different dataset
+python ingest.py -engines "adb,wv" -source "yfcc100m" -load_batch_size 500
+```
+
+### Adding New Engines
+
+1. Create engine modules:
+   - `ingest_newengine.py`
+   - `knn_newengine.py`
+   - `verify_newengine.py`
+
+2. Add engine mapping in main files:
+   - `ingest.py`
+   - `knn.py`
+   - `verify_ingestion.py`
+
+3. Add connector function in `utils.py`
+
+## Requirements
+
+### Python Dependencies
+- `numpy`, `h5py`, `urllib3`, `pandas`
+- `aperturedb` (for ApertureDB)
+- `pinecone` (for Pinecone)
+- `weaviate-client` (for Weaviate)
+- `qdrant-client` (for Qdrant)
+- `lancedb` (for LanceDB)
+
+### Infrastructure
+- Access to target vector databases
+- Sufficient memory for dataset loading
+- Network connectivity for cloud services
+
+## Troubleshooting
+
+### Common Issues
+
+**Missing Dependencies**:
+```
+Failed to import engine pc: No module named 'pinecone'
+```
+*Solution*: Install missing packages or exclude engine from test
+
+**Authentication Errors**:
+```
+Exception: PINECONE_API_KEY not set
+```
+*Solution*: Set required environment variables
+
+**Memory Issues**:
+*Solution*: Use `-minimal true` for smaller datasets
+
+### Debug Mode
+```bash
+# Enable verbose logging
+python knn.py -engines "adb" -verbose true
+
+# Check specific engine
+python verify_ingestion.py -engines "pc" -source "deepimage96"
+```
+
+---
+
+For detailed implementation information, see the individual module documentation and source code.

--- a/apps/vectordb-compare/app/app.sh
+++ b/apps/vectordb-compare/app/app.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+mkdir -p input
+
+# Download required datasets
+./download_data.sh
+
+if [[ "$MINIMAL" == true ]]; then
+
+    export ENGINES=adb # ApertureDB only
+
+    echo "Building aperturedb sets..."
+    python3 ingest.py > output/ingest.log
+
+    echo "Running knn_samples=10..."
+    python3 knn.py -knn_samples=10 -sizes=1000 \
+                   -keep_prev_output=false > output/knn_samples_10.log 2>&1
+
+    echo "Plotting..."
+    python3 plot.py > output/plot.log 2>&1
+
+    echo "Done. Bye!"
+    exit 0
+fi
+
+# if BUILD_SETS is true, then build the sets and exit
+if [[ "$BUILD_SETS" == true ]]; then
+
+    echo "Building sets..."
+    python3 ingest.py > output/ingest.log
+    echo "Done sets."
+    exit 0
+fi
+
+echo "Verifying sets..."
+python3 verify.py > output/verify_sets.log
+
+# if verification fails, exit 1
+if [[ $? -ne 0 ]]; then
+    echo "ERROR: Verification failed."
+    exit 1
+fi
+echo "Verification succeeded."
+
+echo "Running knn_samples=10..."
+python3 knn.py -knn_samples=10  -keep_prev_output=false > output/knn_samples_10.log 2>&1
+
+echo "Running knn_samples=100..."
+python3 knn.py -knn_samples=100 -keep_prev_output=true > output/knn_samples_100.log 2>&1
+
+echo "Plotting..."
+python3 plot.py > output/plot.log 2>&1
+
+echo "Done. Bye!"

--- a/apps/vectordb-compare/app/config.py
+++ b/apps/vectordb-compare/app/config.py
@@ -1,0 +1,262 @@
+"""
+Shared Configuration Class for Vector Database Benchmark
+Centralizes environment variable handling and parameter management
+"""
+
+import os
+import argparse
+from typing import List, Union, Optional
+
+
+class BenchmarkConfig:
+    """
+    Centralized configuration class for vector database benchmarking.
+    Handles environment variables and command line arguments.
+    """
+
+    def __init__(self):
+        # Core dataset parameters
+        self.dataset = os.environ.get('DATASET', "deepimage96")
+        self.dim = self._get_dataset_dimensions()
+        self.minimal = self._str_to_bool(os.environ.get('MINIMAL', False))
+
+        # Ingestion parameters
+        self.load_batch_size = int(os.environ.get('LOAD_BATCHSIZE', 1000))
+        self.load_num_threads = int(os.environ.get('LOAD_NUMTHREADS', 32))
+
+        # KNN/Query parameters
+        self.knn_samples = int(os.environ.get('KNN_SAMPLES', 10))
+        self.total_queries = int(os.environ.get('TOTAL_QUERIES', 100))
+        self.stats_percentile = int(os.environ.get('STATS_PERCENTILE', 90))
+
+        # Engine and size parameters
+        self.engines = self._parse_list(
+            os.environ.get('ENGINES', "adb,pc,wv,qd,ldb"))
+        self.sizes = self._parse_int_list(
+            os.environ.get('SIZES', "1000,10000,100000,1000000"))
+        self.concurrencies = self._parse_int_list(
+            os.environ.get('CONCURRENCIES', "8,16,32,64"))
+
+        # Output and runtime parameters
+        self.keep_prev_output = self._str_to_bool(
+            os.environ.get('KEEP_PREV_OUTPUT', False))
+        self.delete_existing = self._str_to_bool(
+            os.environ.get('DELETE_EXISTING', True))
+        self.run_name = os.environ.get('RUN_NAME', "")
+        self.output_folder = "output"
+        self.verbose = True
+
+        # Metrics (for ingestion)
+        self.metrics = self._parse_list(os.environ.get('METRICS', "CS"))
+
+    def _get_dataset_dimensions(self) -> int:
+        """Get the correct dimensions based on dataset type."""
+        if self.dataset == "deepimage96":
+            return int(os.environ.get('DIM', 96))
+        elif self.dataset == "yfcc100m":
+            return int(os.environ.get('DIM', 4096))
+        else:
+            return int(os.environ.get('DIM', 64))
+
+    def _str_to_bool(self, value: Union[str, bool]) -> bool:
+        """Convert string to boolean."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ('yes', 'true', 't', 'y', '1')
+        return False
+
+    def _parse_list(self, value: str) -> List[str]:
+        """Parse comma-separated string into list of strings."""
+        if not value:
+            return []
+        return [item.strip() for item in value.split(',')]
+
+    def _parse_int_list(self, value: str) -> List[int]:
+        """Parse comma-separated string into list of integers."""
+        if not value:
+            return []
+        return [int(item.strip()) for item in value.split(',')]
+
+    def str_size_to_int(self, size_str: str) -> int:
+        """Convert size string (e.g., '1k', '10k') to integer."""
+        size_mapping = {
+            'k': 1000,
+            'm': 1000000
+        }
+        if size_str[-1] in size_mapping:
+            return int(size_str[:-1]) * size_mapping[size_str[-1]]
+        return int(size_str)
+
+    def get_sizes_to_process(self, minimal: Optional[bool] = None) -> List[str]:
+        """
+        Get list of size strings to process based on minimal flag.
+        Returns size strings like ['1k', '10k', '100k', '1m']
+        """
+        if minimal is None:
+            minimal = self.minimal
+
+        size_mapping = {
+            1000: "1k",
+            10000: "10k",
+            100000: "100k",
+            1000000: "1m"
+        }
+
+        if minimal:
+            return ["1k"]
+        else:
+            return [size_mapping.get(size, str(size)) for size in self.sizes]
+
+    def validate_dataset(self):
+        """Validate that the dataset is supported."""
+        supported_datasets = ["yfcc100m", "deepimage96"]
+        if self.dataset not in supported_datasets:
+            raise ValueError(
+                f"Unknown dataset: {self.dataset}. Supported: {supported_datasets}")
+
+    def update_from_args(self, args: argparse.Namespace):
+        """Update configuration from command line arguments."""
+        for key, value in vars(args).items():
+            if hasattr(self, key) and value is not None:
+                setattr(self, key, value)
+
+    def create_argparser(self, parser_type: str = "common") -> argparse.ArgumentParser:
+        """
+        Create argument parser with appropriate arguments for different script types.
+
+        Args:
+            parser_type: One of 'ingest', 'verify', 'knn', or 'common'
+        """
+        parser = argparse.ArgumentParser()
+
+        # Common arguments for all scripts
+        parser.add_argument('-minimal', type=self._str_to_bool,
+                            default=self.minimal,
+                            help='Run in minimal mode (1k records only)')
+
+        parser.add_argument('-dataset', type=str,
+                            default=self.dataset,
+                            help='Dataset to use (deepimage96, yfcc100m)')
+
+        parser.add_argument('-engines', type=str,
+                            default=','.join(self.engines),
+                            help='Comma-separated list of engines to test')
+
+        parser.add_argument('-output_folder', type=str,
+                            default=self.output_folder,
+                            help='Output folder for results')
+
+        parser.add_argument('-verbose', type=self._str_to_bool,
+                            default=self.verbose,
+                            help='Enable verbose output')
+
+        # Script-specific arguments
+        if parser_type == "ingest":
+            parser.add_argument('-load_batch_size', type=int,
+                                default=self.load_batch_size,
+                                help='Batch size for loading data')
+
+            parser.add_argument('-load_num_threads', type=int,
+                                default=self.load_num_threads,
+                                help='Number of threads for loading')
+
+            parser.add_argument('-metrics', type=str,
+                                default=','.join(self.metrics),
+                                help='Metrics to use')
+
+        elif parser_type == "knn":
+            parser.add_argument('-knn_samples', type=int,
+                                default=self.knn_samples,
+                                help='Number of KNN samples')
+
+            parser.add_argument('-total_queries', type=int,
+                                default=self.total_queries,
+                                help='Total number of queries to run')
+
+            parser.add_argument('-stats_percentile', type=int,
+                                default=self.stats_percentile,
+                                help='Percentile for statistics')
+
+            parser.add_argument('-concurrencies', type=str,
+                                default=','.join(map(str, self.concurrencies)),
+                                help='Comma-separated list of concurrency levels')
+
+            parser.add_argument('-sizes', type=str,
+                                default=','.join(map(str, self.sizes)),
+                                help='Comma-separated list of dataset sizes')
+
+        elif parser_type == "verify":
+            parser.add_argument('-delete_existing', type=self._str_to_bool,
+                                default=self.delete_existing,
+                                help='Delete existing data before verification')
+
+        # Common optional arguments
+        parser.add_argument('-keep_prev_output', type=self._str_to_bool,
+                            default=self.keep_prev_output,
+                            help='Keep previous output files')
+
+        parser.add_argument('-run_name', type=str,
+                            default=self.run_name,
+                            help='Name for this benchmark run')
+
+        return parser
+
+    def __str__(self) -> str:
+        """String representation of configuration."""
+        return (f"BenchmarkConfig("
+                f"dataset={self.dataset}, "
+                f"dim={self.dim}, "
+                f"engines={self.engines}, "
+                f"minimal={self.minimal})")
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+# Global configuration instance
+config = BenchmarkConfig()
+
+
+def get_config() -> BenchmarkConfig:
+    """Get the global configuration instance."""
+    return config
+
+
+def create_config_from_args(parser_type: str = "common",
+                            custom_args: Optional[List[str]] = None) -> BenchmarkConfig:
+    """
+    Create and return a configuration instance from command line arguments.
+
+    Args:
+        parser_type: Type of parser to create ('ingest', 'verify', 'knn', 'common')
+        custom_args: Custom arguments list (for testing), uses sys.argv if None
+
+    Returns:
+        BenchmarkConfig instance configured from command line arguments
+    """
+    config = BenchmarkConfig()
+    parser = config.create_argparser(parser_type)
+
+    if custom_args is not None:
+        args = parser.parse_args(custom_args)
+    else:
+        args = parser.parse_args()
+
+    # Update config with parsed arguments
+    config.update_from_args(args)
+
+    # Parse list arguments
+    if hasattr(args, 'engines'):
+        config.engines = config._parse_list(args.engines)
+    if hasattr(args, 'metrics'):
+        config.metrics = config._parse_list(args.metrics)
+    if hasattr(args, 'concurrencies'):
+        config.concurrencies = config._parse_int_list(args.concurrencies)
+    if hasattr(args, 'sizes'):
+        config.sizes = config._parse_int_list(args.sizes)
+
+    # Validate configuration
+    config.validate_dataset()
+
+    return config

--- a/apps/vectordb-compare/app/download_data.sh
+++ b/apps/vectordb-compare/app/download_data.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+#
+# download_data.sh - Download vector database benchmark datasets from S3
+#
+# This script downloads the required datasets from S3 based on the SOURCE parameter.
+# Supports: deepimage96, yfcc100m
+#
+# Usage: ./download_data.sh [SOURCE]
+# Environment Variables:
+#   SOURCE - Dataset to download (default: deepimage96)
+#
+
+set -euo pipefail  # Exit on error, undefined vars, pipe failures
+IFS=$'\n\t'        # Secure Internal Field Separator
+
+# Script directory and constants
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly INPUT_DIR="${SCRIPT_DIR}/input"
+readonly S3_BUCKET="s3://aperturedb-demos/benchmarks/data/descriptors_knn"
+
+# Supported datasets configuration
+declare -A DATASETS=(
+    ["deepimage96"]="deep-image-96-angular.hdf5"
+    ["yfcc100m"]="YFCC100M_hybridCNN_gmean_fc6_0.bin"
+)
+
+# Default values
+readonly DEFAULT_SOURCE="deepimage96"
+
+#######################################
+# Print usage information
+# Globals:
+#   None
+# Arguments:
+#   None
+#######################################
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Download vector database benchmark datasets from S3.
+
+OPTIONS:
+    -h, --help          Show this help message
+    -s, --source SOURCE Specify dataset source (default: ${DEFAULT_SOURCE})
+                        Supported: $(printf "%s " "${!DATASETS[@]}")
+
+ENVIRONMENT VARIABLES:
+    SOURCE              Dataset to download (overridden by -s option)
+
+EXAMPLES:
+    $0                          # Download default dataset (${DEFAULT_SOURCE})
+    $0 -s yfcc100m             # Download yfcc100m dataset
+    SOURCE=yfcc100m $0         # Download yfcc100m via environment variable
+
+EOF
+}
+
+#######################################
+# Log messages with timestamp
+# Globals:
+#   None
+# Arguments:
+#   $1 - Log level (INFO, ERROR, WARN)
+#   $2 - Message
+#######################################
+log() {
+    local level="$1"
+    local message="$2"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] [${level}] ${message}" >&2
+}
+
+#######################################
+# Log info messages
+# Arguments:
+#   $1 - Message
+#######################################
+log_info() {
+    log "INFO" "$1"
+}
+
+#######################################
+# Log error messages
+# Arguments:
+#   $1 - Message
+#######################################
+log_error() {
+    log "ERROR" "$1"
+}
+
+#######################################
+# Check if required commands are available
+# Globals:
+#   None
+# Arguments:
+#   None
+#######################################
+check_dependencies() {
+    local missing_deps=()
+
+    if ! command -v aws &> /dev/null; then
+        missing_deps+=("aws")
+    fi
+
+    if [[ ${#missing_deps[@]} -gt 0 ]]; then
+        log_error "Missing required dependencies: ${missing_deps[*]}"
+        log_error "Please install the AWS CLI: https://aws.amazon.com/cli/"
+        exit 1
+    fi
+}
+
+#######################################
+# Validate that the dataset source is supported
+# Globals:
+#   DATASETS
+# Arguments:
+#   $1 - Source to validate
+#######################################
+validate_source() {
+    local source="$1"
+
+    if [[ ! -v "DATASETS[$source]" ]]; then
+        log_error "Unsupported dataset source: '$source'"
+        log_error "Supported sources: $(printf "%s " "${!DATASETS[@]}")"
+        return 1
+    fi
+}
+
+#######################################
+# Download dataset from S3
+# Globals:
+#   S3_BUCKET, INPUT_DIR, DATASETS
+# Arguments:
+#   $1 - Dataset source
+#######################################
+download_dataset() {
+    local source="$1"
+    local filename="${DATASETS[$source]}"
+
+    log_info "Downloading ${source} dataset (${filename})..."
+
+    # Check if file already exists and is not empty
+    if [[ -f "${INPUT_DIR}/${filename}" && -s "${INPUT_DIR}/${filename}" ]]; then
+        log_info "Dataset file already exists and is not empty: ${INPUT_DIR}/${filename}"
+        log_info "Skipping download. Remove file to force re-download."
+        return 0
+    fi
+
+    # Create input directory
+    if ! mkdir -p "${INPUT_DIR}"; then
+        log_error "Failed to create input directory: ${INPUT_DIR}"
+        return 1
+    fi
+
+    # Download with aws s3 sync
+    if aws s3 sync "${S3_BUCKET}/" "${INPUT_DIR}/" \
+        --exclude='*' \
+        --include="${filename}" \
+        --no-progress; then
+
+        log_info "Successfully downloaded: ${filename}"
+
+        # Verify file was downloaded and is not empty
+        if [[ -f "${INPUT_DIR}/${filename}" && -s "${INPUT_DIR}/${filename}" ]]; then
+            local file_size
+            file_size=$(du -h "${INPUT_DIR}/${filename}" | cut -f1)
+            log_info "Downloaded file size: ${file_size}"
+        else
+            log_error "Download failed or file is empty: ${INPUT_DIR}/${filename}"
+            return 1
+        fi
+    else
+        log_error "Failed to download dataset from S3"
+        return 1
+    fi
+}
+
+#######################################
+# Parse command line arguments
+# Globals:
+#   SOURCE
+# Arguments:
+#   Command line arguments
+#######################################
+parse_arguments() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -s|--source)
+                if [[ -n "${2:-}" ]]; then
+                    SOURCE="$2"
+                    shift 2
+                else
+                    log_error "Option --source requires an argument"
+                    exit 1
+                fi
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+            *)
+                log_error "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+#######################################
+# Main function
+# Globals:
+#   SOURCE, DEFAULT_SOURCE
+# Arguments:
+#   Command line arguments
+#######################################
+main() {
+    # Parse command line arguments
+    parse_arguments "$@"
+
+    # Set default source if not provided
+    SOURCE="${SOURCE:-${DEFAULT_SOURCE}}"
+
+    # Convert to lowercase for consistency
+    SOURCE="${SOURCE,,}"
+
+    log_info "Starting data download script"
+    log_info "Target dataset: ${SOURCE}"
+    log_info "Input directory: ${INPUT_DIR}"
+
+    # Check dependencies
+    check_dependencies
+
+    # Validate source
+    if ! validate_source "${SOURCE}"; then
+        exit 1
+    fi
+
+    # Download the dataset
+    if download_dataset "${SOURCE}"; then
+        log_info "Dataset download completed successfully"
+    else
+        log_error "Dataset download failed"
+        exit 1
+    fi
+}
+
+# Execute main function if script is run directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/apps/vectordb-compare/app/hdf5.py
+++ b/apps/vectordb-compare/app/hdf5.py
@@ -1,0 +1,25 @@
+import h5py
+filename = "input/deep-image-96-angular.hdf5"
+
+with h5py.File(filename, "r") as f:
+    # Print all root level object names (aka keys)
+    # these can be group or dataset names
+    print("Keys: %s" % f.keys())
+    # get first object name/key; may or may NOT be a group
+    a_group_key = list(f.keys())[2]
+
+    # get the object type for a_group_key: usually group or dataset
+    print(type(f[a_group_key]))
+
+    # If a_group_key is a group name,
+    # this gets the object names in the group and returns as a list
+    data = list(f[a_group_key])
+
+    # If a_group_key is a dataset name,
+    # this gets the dataset values and returns as a list
+    data = list(f[a_group_key])
+    # preferred methods to get dataset values:
+    # ds_obj = f[a_group_key]      # returns as a h5py dataset object
+    ds_arr = f[a_group_key][()]  # returns as a numpy array
+
+    print(f"len ds_arr: {len(ds_arr[0])}")

--- a/apps/vectordb-compare/app/ingest.py
+++ b/apps/vectordb-compare/app/ingest.py
@@ -1,0 +1,168 @@
+"""
+Main Ingestion Runner with Dynamic Engine Loading
+"""
+
+import os
+import argparse
+import importlib
+import time
+from collections import defaultdict
+from config import create_config_from_args
+
+
+def load_ingestion_engine(engine_name):
+    """
+    Dynamically load ingestion engine module to avoid import issues when engine is not used.
+    """
+    engine_mapping = {
+        'adb': 'ingest_aperturedb',
+        'pc': 'ingest_pinecone',
+        'wv': 'ingest_weaviate',
+        'qd': 'ingest_qdrant',
+        'ldb': 'ingest_lancedb'
+    }
+
+    module_name = engine_mapping.get(engine_name)
+    if not module_name:
+        raise ValueError(f"Unknown engine: {engine_name}")
+
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        print(f"Failed to import engine {engine_name}: {e}")
+        print(f"Skipping {engine_name} - required dependencies not available")
+        return None
+
+
+def run_engine_ingestion(engine_name, params, timing_data):
+    """Run ingestion for a specific engine and collect timing data."""
+    module = load_ingestion_engine(engine_name)
+    if not module:
+        return False
+
+    # Record start time
+    engine_start_time = time.time()
+
+    engine_instance = None
+    if engine_name == 'adb':
+        engine_instance = module.run_aperturedb_ingestion(params)
+    elif engine_name == 'pc':
+        engine_instance = module.run_pinecone_ingestion(params)
+    elif engine_name == 'wv':
+        engine_instance = module.run_weaviate_ingestion(params)
+    elif engine_name == 'qd':
+        engine_instance = module.run_qdrant_ingestion(params)
+    elif engine_name == 'ldb':
+        engine_instance = module.run_lancedb_ingestion(params)
+
+    # Record end time and calculate duration
+    engine_end_time = time.time()
+    total_duration = engine_end_time - engine_start_time
+
+    # Get detailed timing data from the engine if available
+    if engine_instance and hasattr(engine_instance, 'get_timing_data'):
+        detailed_timing = engine_instance.get_timing_data()
+        timing_data[engine_name.upper()].update(detailed_timing)
+
+    # Always record total time
+    timing_data[engine_name.upper()]['total'] = total_duration
+
+    return True
+
+
+def print_timing_summary(timing_data, params):
+    """Print a summary table of ingestion times."""
+    print("\n" + "=" * 80)
+    print("INGESTION TIMING SUMMARY")
+    print("=" * 80)
+
+    # Get dataset sizes
+    sizes = ["1k"] if params.minimal else ["1k", "10k", "100k", "1m"]
+
+    # Print table header
+    header = f"{'Engine':<12}"
+    for size in sizes:
+        header += f"{size:>12}"
+    header += f"{'Total (s)':>12}"
+    print(header)
+    print("-" * len(header))
+
+    # Print data for each engine
+    for engine, data in timing_data.items():
+        if data:  # Only print engines that actually ran
+            row = f"{engine:<12}"
+
+            # Check if we have detailed per-size timing data
+            has_detailed_timing = any(size in data for size in sizes)
+
+            if has_detailed_timing:
+                # Use actual per-size timing data
+                for size in sizes:
+                    if size in data:
+                        row += f"{data[size]:>11.1f}s"
+                    else:
+                        row += f"{'N/A':>12}"
+            else:
+                # Fall back to distributing total time evenly
+                if 'total' in data:
+                    avg_time = data['total'] / len(sizes)
+                    for size in sizes:
+                        row += f"{avg_time:>11.1f}s"
+                else:
+                    for size in sizes:
+                        row += f"{'N/A':>12}"
+
+            # Add total time
+            if 'total' in data:
+                row += f"{data['total']:>11.1f}s"
+            else:
+                row += f"{'N/A':>12}"
+
+            print(row)
+
+    print("-" * len(header))
+    print(f"\nDataset: {params.dataset}")
+    print(f"Dimensions: {params.dim}")
+    print(f"Batch size: {params.load_batch_size}")
+    print(f"Threads: {params.load_num_threads}")
+    if params.minimal:
+        print("Mode: Minimal (1k records only)")
+    else:
+        print("Mode: Full (1k, 10k, 100k, 1m records)")
+    print("=" * 80)
+
+
+def main(params):
+    """Main ingestion runner with dynamic engine loading."""
+    # Initialize timing data collection
+    timing_data = defaultdict(dict)
+
+    try:
+        for engine in params.engines:
+            print(f"Running ingestion with {engine.upper()}...")
+            success = run_engine_ingestion(engine, params, timing_data)
+            if success:
+                print(f"✓ {engine.upper()} ingestion completed")
+            else:
+                print(
+                    f"✗ {engine.upper()} ingestion skipped due to missing dependencies")
+            print("-" * 50)
+
+        # Print timing summary after all engines complete
+        if timing_data:
+            print_timing_summary(timing_data, params)
+
+    except Exception as e:
+        print("Failed!")
+        print(e)
+        exit(1)
+
+
+def get_args():
+    """Parse command line arguments using centralized config."""
+    return create_config_from_args("ingest")
+
+
+if __name__ == "__main__":
+    args = get_args()
+    main(args)

--- a/apps/vectordb-compare/app/ingest_aperturedb.py
+++ b/apps/vectordb-compare/app/ingest_aperturedb.py
@@ -1,0 +1,144 @@
+"""
+ApertureDB Ingestion Engine Implementation
+"""
+
+import time
+import numpy as np
+
+from ingest_base import IngestionEngine
+
+# ApertureDB imports - only imported when this module is used
+from aperturedb import Utils, CommonLibrary
+from aperturedb import QueryGenerator
+from aperturedb import ParallelLoader
+
+
+class DeepImage96Generator(QueryGenerator.QueryGenerator):
+    """Deep Image 96 dataset generator for ApertureDB."""
+
+    def __init__(self, dataset, set_name="yfcc_descriptors"):
+        self.set_name = set_name
+        self.dataset = dataset
+        self.len = len(self.dataset)
+        self.dim = len(self.dataset[0])
+
+    def __len__(self):
+        return self.len
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        descriptor = self.dataset[idx].astype('float32').tobytes()
+        assert (len(descriptor) / 4 == self.dim)
+
+        q = [{
+            "AddDescriptor": {
+                "set": self.set_name,
+                "properties": {
+                    "deep_img_id": idx,
+                },
+            }
+        }]
+
+        return q, [descriptor]
+
+
+class YFCC100MDescriptorsGenerator(QueryGenerator.QueryGenerator):
+    """YFCC100M dataset generator for ApertureDB."""
+
+    def __init__(self, dataset, set_name="yfcc_descriptors"):
+        self.set_name = set_name
+        self.dataset = dataset
+        self.len = len(self.dataset)
+        self.dim = len(self.dataset[0])
+
+    def __len__(self):
+        return self.len
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        descriptor = self.dataset[idx].astype('float32').tobytes()
+        assert (len(descriptor) / 4 == self.dim)
+
+        q = [{
+            "AddDescriptor": {
+                "set": self.set_name,
+                "properties": {
+                    "yfcc_id": idx,
+                },
+            }
+        }]
+
+        return q, [descriptor]
+
+
+class ApertureDBIngestionEngine(IngestionEngine):
+    """ApertureDB ingestion engine."""
+
+    def __init__(self):
+        super().__init__("adb")
+
+    def ingest_data(self, params):
+        """Ingest data into ApertureDB."""
+        db = CommonLibrary.create_connector()
+        dbutils = Utils.Utils(db)
+
+        self.log_progress(f"ApertureDB status: {dbutils.status()}")
+
+        # Create important indexes for performance
+        dbutils.create_entity_index("_Descriptor", "_create_txn")
+        dbutils.create_entity_index("_DescriptorSet", "_name")
+
+        sizes = self.get_sizes_to_process(params.minimal)
+
+        for s in sizes:
+            set_name = f"{params.dataset}_{s}"
+
+            self.log_progress(f"Starting load of set={set_name}...")
+
+            # Get dataset
+            dataset = self.get_dataset(params.dataset, self.size_to_count(s))
+
+            # Create generator
+            if params.dataset == "deepimage96":
+                generator = DeepImage96Generator(dataset, set_name=set_name)
+            elif params.dataset == "yfcc100m":
+                generator = YFCC100MDescriptorsGenerator(
+                    dataset, set_name=set_name)
+
+            self.log_progress(f"Dataset loaded.")
+
+            # Remove existing data
+            self.log_progress(f"Deleting existing vectors ...")
+            dbutils.remove_descriptorset(set_name)
+            self.log_progress(f"Done.")
+
+            # Add descriptor set
+            dbutils.add_descriptorset(set_name, generator.dim, "CS", "HNSW")
+
+            self.log_progress(f"Adding {s} vectors ...")
+
+            # Ingest data
+            start_time = time.time()
+            loader = ParallelLoader.ParallelLoader(db)
+            loader.ingest(generator,
+                          batchsize=params.load_batch_size,
+                          numthreads=params.load_num_threads,
+                          stats=params.verbose)
+
+            duration = time.time() - start_time
+            self.log_progress(
+                f"Done {s}. Upsert elapsed time: {duration:.2f} s")
+
+            # Record timing data for this size
+            self.record_timing(s, duration)
+
+
+def run_aperturedb_ingestion(params):
+    """Entry point for ApertureDB ingestion."""
+    engine = ApertureDBIngestionEngine()
+    engine.ingest_data(params)
+    return engine

--- a/apps/vectordb-compare/app/ingest_base.py
+++ b/apps/vectordb-compare/app/ingest_base.py
@@ -1,0 +1,55 @@
+"""
+Base classes and shared utilities for ingestion engines.
+"""
+
+import os
+import time
+from abc import ABC, abstractmethod
+from collections import defaultdict
+
+import utils as u
+
+
+class IngestionEngine(ABC):
+    """Abstract base class for ingestion engines."""
+
+    def __init__(self, engine_name):
+        self.engine_name = engine_name
+        self.timing_data = defaultdict(float)
+
+    @abstractmethod
+    def ingest_data(self, params):
+        """Ingest data for this engine."""
+        pass
+
+    def get_dataset(self, source, size):
+        """Get dataset based on source and size."""
+        if source == "deepimage96":
+            return u.DatasetDeepImage96(max=size).dataset
+        elif source == "yfcc100m":
+            return u.DatasetYFCC100M(max=size).dataset
+        else:
+            raise ValueError(f"Unknown source: {source}")
+
+    def get_sizes_to_process(self, minimal=False):
+        """Get list of sizes to process."""
+        if minimal:
+            return ["1k"]
+        return ["1k", "10k", "100k", "1m"]
+
+    def size_to_count(self, size_str):
+        """Convert size string to count."""
+        size_map = {"1k": 1000, "10k": 10000, "100k": 100000, "1m": 1000000}
+        return size_map.get(size_str)
+
+    def log_progress(self, message):
+        """Log progress message."""
+        print(message)
+
+    def record_timing(self, size_str, duration):
+        """Record timing for a specific dataset size."""
+        self.timing_data[size_str] = duration
+
+    def get_timing_data(self):
+        """Get collected timing data."""
+        return dict(self.timing_data)

--- a/apps/vectordb-compare/app/ingest_lancedb.py
+++ b/apps/vectordb-compare/app/ingest_lancedb.py
@@ -1,0 +1,109 @@
+"""
+LanceDB Ingestion Engine Implementation
+"""
+
+import time
+import os
+import tempfile
+import shutil
+
+from ingest_base import IngestionEngine
+import utils as u
+
+
+class LanceDBIngestionEngine(IngestionEngine):
+    """LanceDB ingestion engine."""
+
+    def __init__(self):
+        super().__init__("ldb")
+
+    def ingest_data(self, params):
+        """Ingest data into LanceDB."""
+        import pandas as pd
+
+        # Use centralized connector from utils
+        db = u.create_connector_lancedb()
+
+        self.log_progress(f"Connected to LanceDB Cloud")
+
+        sizes = self.get_sizes_to_process(params.minimal)
+        size_count = 1000
+
+        for s in sizes:
+            table_name = f"{params.dataset}_{s}"
+            self.log_progress(f"Starting load of table={table_name}...")
+
+            # Load dataset
+            self.log_progress(f"Loading {size_count} descriptors ...")
+            dataset = self.get_dataset(params.dataset, size_count)
+            self.log_progress(f"Dataset dimensions: {len(dataset[0])}")
+            self.log_progress(f"Done.")
+
+            # Drop existing table if it exists
+            try:
+                if table_name in db.table_names():
+                    db.drop_table(table_name)
+                    self.log_progress(f"Dropped existing table: {table_name}")
+            except Exception as e:
+                self.log_progress(
+                    f"Warning: Could not drop table {table_name}: {e}")
+
+            # Prepare data for ingestion
+            self.log_progress(f"Preparing data for ingestion...")
+
+            # Create table and ingest data in batches
+            self.log_progress(f"Adding {size_count} vectors...")
+            start_time = time.time()
+
+            # Create list of records with vector and metadata
+            records = []
+            for i in range(size_count):
+                vector = dataset[i].astype('float32').tolist()
+                record = {
+                    'id': i,
+                    'vector': vector
+                }
+
+                # Add source-specific metadata
+                if params.dataset == "deepimage96":
+                    record['deep_img_id'] = i
+                elif params.dataset == "yfcc100m":
+                    record['yfcc_id'] = i
+
+                records.append(record)
+
+            # Process in batches to avoid memory issues
+            batch_size = min(params.load_batch_size, 1000)
+
+            # Create table with first batch
+            first_batch = records[:batch_size]
+            df = pd.DataFrame(first_batch)
+            table = db.create_table(table_name, df)
+
+            # Add remaining batches
+            for i in range(batch_size, len(records), batch_size):
+                batch = records[i:i + batch_size]
+                batch_df = pd.DataFrame(batch)
+                table.add(batch_df)
+
+            # LanceDB automatically creates optimal indexes internally
+            # Skip explicit index creation as it may cause API compatibility issues
+            self.log_progress(
+                f"Using LanceDB's automatic indexing (HNSW-based)")
+
+            # Note: LanceDB automatically creates efficient indexes for vector columns
+            # Manual index creation is often not needed and can cause compatibility issues
+            # with different LanceDB versions
+
+            elapsed_time = time.time() - start_time
+            self.log_progress(
+                f"Done {s}. Ingestion elapsed time: {elapsed_time:.2f} s")
+
+            size_count *= 10
+
+
+def run_lancedb_ingestion(params):
+    """Entry point for LanceDB ingestion."""
+    engine = LanceDBIngestionEngine()
+    engine.ingest_data(params)
+    return engine

--- a/apps/vectordb-compare/app/ingest_pinecone.py
+++ b/apps/vectordb-compare/app/ingest_pinecone.py
@@ -1,0 +1,102 @@
+"""
+Pinecone Ingestion Engine Implementation
+"""
+
+import time
+import itertools
+
+from ingest_base import IngestionEngine
+import utils as u
+
+
+class PineconeIngestionEngine(IngestionEngine):
+    """Pinecone ingestion engine."""
+
+    def __init__(self):
+        super().__init__("pc")
+
+    def chunks(self, iterable, batch_size):
+        """A helper function to break an iterable into chunks of size batch_size."""
+        it = iter(iterable)
+        while True:
+            chunk = list(itertools.islice(it, batch_size))
+            if not chunk:
+                break
+            yield chunk
+
+    def ingest_data(self, params):
+        """Ingest data into Pinecone."""
+        pc = u.create_connector_pinecone(grpc=False)
+
+        index_name = f"knn-{params.dataset}"
+        index = pc.Index(index_name)
+
+        sizes = self.get_sizes_to_process(params.minimal)
+        size_count = 1000
+
+        for s in sizes:
+            namespace = f"{params.dataset}_{s}"
+            self.log_progress(f"Starting load of namespace={namespace}...")
+
+            # Load dataset
+            self.log_progress(f"Loading {namespace} descriptors ...")
+            dataset = self.get_dataset(params.dataset, size_count)
+            self.log_progress(f"Dataset dimensions: {len(dataset[0])}")
+            self.log_progress(f"Done.")
+
+            # Prepare data generator
+            data_generator = map(lambda i: (
+                f'id-{i}', dataset[i]), range(size_count))
+
+            self.log_progress(f"Deleting existing vectors ...")
+            # Create a dummy vector to initialize namespace if it doesn't exist
+            index.upsert(
+                vectors=[
+                    {
+                        "id": f"id-{0}",
+                        "values": dataset[0].tolist()
+                    }
+                ],
+                async_req=False,
+                namespace=namespace
+            )
+
+            # Delete all vectors in namespace
+            index.delete(delete_all=True, namespace=namespace)
+            self.log_progress(f"Done.")
+
+            self.log_progress(f"Adding {s} vectors ...")
+
+            # Batch upsert vectors
+            start_time = time.time()
+
+            for chunk in self.chunks(data_generator, params.load_batch_size):
+                vectors_to_upsert = [
+                    {
+                        "id": vector_id,
+                        "values": vector_data.tolist()
+                    }
+                    for vector_id, vector_data in chunk
+                ]
+
+                index.upsert(
+                    vectors=vectors_to_upsert,
+                    async_req=False,
+                    namespace=namespace
+                )
+
+            duration = time.time() - start_time
+            self.log_progress(
+                f"Done {s}. Upsert elapsed time: {duration:.2f} s")
+
+            # Record timing data for this size
+            self.record_timing(s, duration)
+
+            size_count *= 10
+
+
+def run_pinecone_ingestion(params):
+    """Entry point for Pinecone ingestion."""
+    engine = PineconeIngestionEngine()
+    engine.ingest_data(params)
+    return engine

--- a/apps/vectordb-compare/app/ingest_qdrant.py
+++ b/apps/vectordb-compare/app/ingest_qdrant.py
@@ -1,0 +1,95 @@
+"""
+Qdrant Ingestion Engine Implementation
+"""
+
+import time
+import itertools
+
+from ingest_base import IngestionEngine
+import utils as u
+
+
+class QdrantIngestionEngine(IngestionEngine):
+    """Qdrant ingestion engine."""
+
+    def __init__(self):
+        super().__init__("qd")
+
+    def chunks(self, iterable, batch_size):
+        """A helper function to break an iterable into chunks of size batch_size."""
+        it = iter(iterable)
+        while True:
+            chunk = list(itertools.islice(it, batch_size))
+            if not chunk:
+                break
+            yield chunk
+
+    def ingest_data(self, params):
+        """Ingest data into Qdrant."""
+        # Import qdrant modules only when needed
+        from qdrant_client import models
+        from qdrant_client.http.models import PointStruct
+
+        client = u.create_connector_qdrant()
+
+        self.log_progress(f"Qdrant collections: {client.get_collections()}")
+
+        sizes = self.get_sizes_to_process(params.minimal)
+        size_count = 1000
+
+        for s in sizes:
+            collection_name = f"{params.dataset}_{s}"
+
+            self.log_progress(f"Starting load of namespace={s}...")
+
+            # Load dataset
+            self.log_progress(f"Loading {params.dataset} descriptors ...")
+            dataset = self.get_dataset(params.dataset, size_count)
+            self.log_progress(f"Done.")
+
+            # Delete existing collection
+            self.log_progress(f"Deleting existing vectors...")
+            client.delete_collection(collection_name=collection_name)
+            self.log_progress(f"Done.")
+
+            # Create collection
+            self.log_progress(f"Creating collection...")
+            client.create_collection(
+                collection_name=collection_name,
+                vectors_config=models.VectorParams(
+                    size=len(dataset[0]), distance=models.Distance.COSINE),
+            )
+            self.log_progress(f"Done.")
+
+            self.log_progress(f"Adding {s} vectors ...")
+
+            # Batch upsert vectors
+            start_time = time.time()
+
+            # Prepare points in batches
+            points = [
+                PointStruct(
+                    id=i, vector=dataset[i].tolist(), payload={"id": i})
+                for i in range(size_count)
+            ]
+
+            # Upload in chunks
+            for chunk in self.chunks(points, params.load_batch_size):
+                client.upsert(
+                    collection_name=collection_name,
+                    wait=True,
+                    points=chunk
+                )
+
+            self.log_progress(
+                f"Done {s}. Upsert elapsed time: {time.time() - start_time:.2f} s")
+            size_count *= 10
+
+        client.close()
+
+
+def run_qdrant_ingestion(params):
+    """Entry point for Qdrant ingestion."""
+    engine = QdrantIngestionEngine()
+    engine.ingest_data(params)
+    return engine

--- a/apps/vectordb-compare/app/ingest_weaviate.py
+++ b/apps/vectordb-compare/app/ingest_weaviate.py
@@ -1,0 +1,88 @@
+"""
+Weaviate Ingestion Engine Implementation
+"""
+
+import time
+import itertools
+
+from ingest_base import IngestionEngine
+import utils as u
+
+
+class WeaviateIngestionEngine(IngestionEngine):
+    """Weaviate ingestion engine."""
+
+    def __init__(self):
+        super().__init__("wv")
+
+    def ingest_data(self, params):
+        """Ingest data into Weaviate."""
+        # Import weaviate modules only when needed
+        import weaviate
+        from weaviate.classes.config import Configure, Property, DataType
+        from weaviate.classes.data import DataObject
+
+        sizes = self.get_sizes_to_process(params.minimal)
+
+        for s in sizes:
+            size_count = params.str_size_to_int(s)
+            client = u.create_connector_weaviate()
+            collection_name = f"{params.dataset}_{s}"
+
+            try:
+                self.log_progress(f"Starting load of namespace={s}...")
+
+                # Load dataset
+                self.log_progress(f"Loading {params.dataset} descriptors ...")
+                dataset = self.get_dataset(params.dataset, size_count)
+                self.log_progress(f"Done.")
+
+                # Delete existing collection
+                self.log_progress(f"Deleting existing vectors...")
+                client.collections.delete(collection_name)
+                self.log_progress(f"Done.")
+
+                # Create collection
+                client.collections.create(
+                    collection_name,
+                    properties=[
+                        Property(name="test", data_type=DataType.INT),
+                    ],
+                    vector_config=Configure.Vectors.self_provided(
+                        vector_index_config=Configure.VectorIndex.hnsw()
+                    )
+                )
+
+                collection = client.collections.get(collection_name)
+
+                self.log_progress(f"Adding {s} vectors ...")
+
+                # Batch insert vectors
+                start_time = time.time()
+
+                # Prepare data in batches
+                batch_size = params.load_batch_size
+                for i in range(0, size_count, batch_size):
+                    end_idx = min(i + batch_size, size_count)
+                    batch_objects = []
+
+                    for idx in range(i, end_idx):
+                        batch_objects.append(DataObject(
+                            properties={"test": idx},
+                            vector=dataset[idx].tolist()
+                        ))
+
+                    collection.data.insert_many(batch_objects)
+
+                self.log_progress(
+                    f"Done {s}. Upsert elapsed time: {time.time() - start_time:.2f} s")
+
+            finally:
+                client.close()
+
+
+def run_weaviate_ingestion(params):
+    """Entry point for Weaviate ingestion."""
+    engine = WeaviateIngestionEngine()
+    engine.ingest_data(params)
+    return engine

--- a/apps/vectordb-compare/app/knn.py
+++ b/apps/vectordb-compare/app/knn.py
@@ -1,0 +1,144 @@
+"""
+Main KNN Benchmark Runner with Dynamic Engine Loading
+"""
+
+import os
+import argparse
+import importlib
+from dbeval import EvalTool
+from config import create_config_from_args
+
+
+def load_engine_module(engine_name):
+    """
+    Dynamically load engine module to avoid import issues when engine is not used.
+    """
+    engine_mapping = {
+        'adb': 'knn_aperturedb',
+        'adb_rest': 'knn_aperturedb',
+        'pc': 'knn_pinecone',
+        'pc_grpc': 'knn_pinecone',
+        'wv': 'knn_weaviate',
+        'qd': 'knn_qdrant',
+        'ldb': 'knn_lancedb'
+    }
+
+    module_name = engine_mapping.get(engine_name)
+    if not module_name:
+        raise ValueError(f"Unknown engine: {engine_name}")
+
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        print(f"Failed to import engine {engine_name}: {e}")
+        print(f"Skipping {engine_name} - required dependencies not available")
+        return None
+
+
+def main(params):
+    """Main benchmark runner with dynamic engine loading."""
+
+    if not params.keep_prev_output:
+        eval_name = os.path.join(params.output_folder, "knn_comp")
+        e_knn = EvalTool.EvalTool(eval_name)
+        e_knn.clear()
+
+    # Track which engines actually ran
+    successful_engines = []
+
+    try:
+        if "adb" in params.engines:
+            print("Running knn with ApertureDB with TCP...")
+            module = load_engine_module("adb")
+            if module:
+                try:
+                    module.run_knn_aperturedb(params, False)
+                    successful_engines.append("adb")
+                    print("✅ ApertureDB (TCP) completed successfully")
+                except Exception as e:
+                    print(f"❌ ApertureDB (TCP) failed: {e}")
+
+        if "adb_rest" in params.engines:
+            print("Running knn with ApertureDB with REST...")
+            module = load_engine_module("adb_rest")
+            if module:
+                try:
+                    module.run_knn_aperturedb(params, True)
+                    # Keep separate for verification
+                    successful_engines.append("adb_rest")
+                    print("✅ ApertureDB (REST) completed successfully")
+                except Exception as e:
+                    print(f"❌ ApertureDB (REST) failed: {e}")
+
+        if "pc" in params.engines:
+            print("Running knn with Pinecone...")
+            module = load_engine_module("pc")
+            if module:
+                try:
+                    module.run_knn_pinecone(params, False)
+                    successful_engines.append("pc")
+                    print("✅ Pinecone completed successfully")
+                except Exception as e:
+                    print(f"❌ Pinecone failed: {e}")
+
+        if "pc_grpc" in params.engines:
+            print("Running knn with Pinecone with gRPC...")
+            module = load_engine_module("pc_grpc")
+            if module:
+                try:
+                    module.run_knn_pinecone(params, True)
+                    successful_engines.append("pc_grpc")
+                    print("✅ Pinecone (gRPC) completed successfully")
+                except Exception as e:
+                    print(f"❌ Pinecone (gRPC) failed: {e}")
+
+        if "wv" in params.engines:
+            print("Running knn with Weaviate...")
+            module = load_engine_module("wv")
+            if module:
+                try:
+                    module.run_knn_weaviate(params)
+                    successful_engines.append("wv")
+                    print("✅ Weaviate completed successfully")
+                except Exception as e:
+                    print(f"❌ Weaviate failed: {e}")
+
+        if "qd" in params.engines:
+            print("Running knn with Qdrant...")
+            module = load_engine_module("qd")
+            if module:
+                try:
+                    module.run_knn_qdrant(params)
+                    successful_engines.append("qd")
+                    print("✅ Qdrant completed successfully")
+                except Exception as e:
+                    print(f"❌ Qdrant failed: {e}")
+
+        if "ldb" in params.engines:
+            print("Running knn with LanceDB...")
+            module = load_engine_module("ldb")
+            if module:
+                try:
+                    module.run_lancedb_knn(params)
+                    successful_engines.append("ldb")
+                    print("✅ LanceDB completed successfully")
+                except Exception as e:
+                    print(f"❌ LanceDB failed: {e}")
+
+    except Exception as e:
+        print("Failed!")
+        print(e)
+        exit(1)
+
+
+def get_args():
+    """Parse command line arguments using centralized config."""
+    return create_config_from_args("knn")
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    print(f"Running benchmark with parameters: {args}")
+
+    main(args)

--- a/apps/vectordb-compare/app/knn_aperturedb.py
+++ b/apps/vectordb-compare/app/knn_aperturedb.py
@@ -1,0 +1,137 @@
+"""
+ApertureDB KNN Engine Implementation
+"""
+
+import os
+import time
+import threading
+import numpy as np
+
+from knn_base import KNNEngine, QueryGenerator, size_to_str
+
+# ApertureDB imports - only imported when this module is used
+from aperturedb import Utils, CommonLibrary
+from aperturedb import Connector, ConnectorRest
+from aperturedb import QueryGenerator as ADBQueryGenerator
+from aperturedb import ParallelQuery
+
+
+class QueryGeneratorApertureDB(QueryGenerator):
+    """ApertureDB specific query generator."""
+
+    def __init__(self, n_queries, set_name, k_neighbors, dataset):
+        super().__init__(n_queries, k_neighbors, dataset)
+        self.set_name = set_name
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        descriptor = self.dataset[idx].astype('float32').tobytes()
+        assert (len(descriptor) / 4 == self.dim)
+
+        q = [{
+            "FindDescriptor": {
+                "set":         self.set_name,
+                "k_neighbors": self.k_neighbors,
+                "distances":   True,
+                "results": {
+                    "all_properties": True
+                }
+            }
+        }]
+
+        return q, [descriptor]
+
+    def response_handler(self, q, b, r, r_b):
+        assert (r[0]["FindDescriptor"]["returned"] == self.k_neighbors)
+
+
+def worker_aperturedb(db, set_name, generator, knn_samples, start_index, end_index, times, results):
+    """Worker function for ApertureDB threading."""
+    local_db = CommonLibrary.create_connector()
+
+    for i in range(start_index, end_index + 1):
+        if i >= len(generator):
+            break
+
+        query, blobs = generator[i]
+        start_time = time.time()
+        response, _ = local_db.query(query, blobs)
+        assert (response[0]["FindDescriptor"]["returned"] == knn_samples)
+
+        times[i] = time.time() - start_time
+
+        entities = response[0]["FindDescriptor"]["entities"]
+        prop = "deep_img_id" if "deep" in set_name else "yfcc_id"
+        for j in range(len(entities)):
+            results[i][j] = entities[j][prop]
+
+
+class ApertureDBEngine(KNNEngine):
+    """ApertureDB KNN benchmark engine."""
+
+    def __init__(self):
+        super().__init__("aperturedb")
+
+    def run_benchmark(self, params, use_rest=False):
+        """Run ApertureDB KNN benchmark."""
+        e_knn = self.setup_eval_tool(params)
+        db = CommonLibrary.create_connector()
+
+        # print all parameters
+        print(f"Running ApertureDB KNN benchmark with parameters:")
+        for key, value in params.__dict__.items():
+            print(f"  {key}: {value}")
+
+        for s in params.sizes:
+            for c in params.concurrencies:
+                print(f"Running knn for {size_to_str(s)} on {c} threads...")
+
+                set_name = f"{params.dataset}_{size_to_str(s)}"
+
+                generator = QueryGeneratorApertureDB(
+                    params.total_queries, set_name=set_name,
+                    k_neighbors=params.knn_samples, dataset=params.dataset)
+
+                threads = []
+                times = [0.0 for _ in range(len(generator))]
+                results = [[0 for _ in range(params.knn_samples)]
+                           for _ in range(len(generator))]
+
+                th_queue_size = len(generator) // c
+                for i in range(c):
+                    start_index = i * len(generator) // c
+                    end_index = min(
+                        start_index + th_queue_size, len(generator))
+
+                    t = threading.Thread(target=worker_aperturedb, args=(
+                        db, set_name, generator, params.knn_samples, start_index, end_index, times, results))
+                    threads.append(t)
+                    t.start()
+
+                for t in threads:
+                    t.join()
+
+                # Use different engine names for TCP vs REST to avoid file overwriting
+                engine_name = "adb_rest" if use_rest else "adb"
+                # Use detailed name for performance metrics
+                engine_perf_name = "adb_th_rest" if use_rest else "adb_th"
+
+                knn_times = np.percentile(
+                    np.array(times), params.stats_percentile)
+                e_knn.add_row(f"knn_{params.knn_samples}", f"{engine_perf_name}_perc_{params.stats_percentile}", s, c, params.total_queries,
+                              knn_times, 0,  # ith percentile is a single value
+                              params.knn_samples, 0)
+
+                self.log_percentiles(times)
+                # Use different engine names for file writing to avoid conflicts
+                self.write_results(results, engine_name, set_name)
+
+        e_knn.export_to_csv()
+
+
+def run_knn_aperturedb(params, use_rest=False):
+    """Entry point for ApertureDB KNN benchmark."""
+    engine = ApertureDBEngine()
+    engine.run_benchmark(params, use_rest)

--- a/apps/vectordb-compare/app/knn_base.py
+++ b/apps/vectordb-compare/app/knn_base.py
@@ -1,0 +1,86 @@
+"""
+Base classes and shared utilities for KNN benchmarking engines.
+"""
+
+import logging
+import os
+import time
+import numpy as np
+from abc import ABC, abstractmethod
+
+import utils as u
+from dbeval import EvalTool
+
+
+def size_to_str(s):
+    """Convert size to string representation."""
+    if s == 1000:
+        return "1k"
+    elif s == 10000:
+        return "10k"
+    elif s == 100000:
+        return "100k"
+    elif s == 1000000:
+        return "1m"
+
+
+class KNNEngine(ABC):
+    """Abstract base class for KNN benchmark engines."""
+
+    def __init__(self, engine_name):
+        self.engine_name = engine_name
+
+    @abstractmethod
+    def run_benchmark(self, params):
+        """Run the KNN benchmark for this engine."""
+        pass
+
+    def setup_eval_tool(self, params):
+        """Setup the evaluation tool."""
+        eval_name = os.path.join(params.output_folder, "knn_comp")
+        return EvalTool.EvalTool(eval_name)
+
+    def log_percentiles(self, times):
+        """Log timing percentiles."""
+        u.print_percentiles(times)
+
+    def write_results(self, results, engine, namespace):
+        """Write results to file."""
+        u.write_results_to_file(results, engine, namespace)
+
+
+class QueryGenerator(ABC):
+    """Abstract base class for query generators."""
+
+    def __init__(self, n_queries, k_neighbors, dataset):
+        self.k_neighbors = k_neighbors
+
+        if dataset == "deepimage96":
+            dataset_obj = u.DatasetDeepImage96(max=n_queries)
+            self.dataset = dataset_obj.test  # Use test vectors for queries
+        elif dataset == "yfcc100m":
+            dataset_obj = u.DatasetYFCC100M(max=n_queries)
+            self.dataset = dataset_obj.test  # Use test vectors for queries
+
+        if len(self.dataset) == 0:
+            raise ValueError("Dataset vectors have zero length.")
+
+        if len(self.dataset) < n_queries:
+            raise ValueError(
+                f"Requested {n_queries} queries, but dataset only has {len(self.dataset)} vectors.")
+
+        self.dataset = self.dataset[:n_queries]  # Truncate to n_queries
+
+        self.len = len(self.dataset)
+        self.dim = len(self.dataset[0])
+
+    def __len__(self):
+        return self.len
+
+    @abstractmethod
+    def getitem(self, idx):
+        """Get query item at index."""
+        pass
+
+    def __getitem__(self, idx):
+        return self.getitem(idx)

--- a/apps/vectordb-compare/app/knn_lancedb.py
+++ b/apps/vectordb-compare/app/knn_lancedb.py
@@ -1,0 +1,252 @@
+"""
+LanceDB KNN Engine Implementation
+"""
+
+import os
+import time
+import threading
+import numpy as np
+
+from knn_base import KNNEngine, QueryGenerator, size_to_str
+import utils as u
+from dbeval import EvalTool
+
+
+class QueryGeneratorLanceDB(QueryGenerator):
+    """LanceDB specific query generator."""
+
+    def __init__(self, n_queries=int(1e6), table_name="yfcc_descriptors", k_neighbors=10,
+                 dataset="yfcc100m", db=None):
+        super().__init__(n_queries, k_neighbors, dataset)
+        self.table_name = table_name
+        self.db = db
+        self.table = None
+
+        # Get the table reference
+        if self.db and table_name in self.db.table_names():
+            self.table = self.db.open_table(table_name)
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        # Get query vector
+        query_vector = self.dataset[idx].astype('float32').tolist()
+        return query_vector, None
+
+    def search(self, query_vector):
+        """Perform KNN search using LanceDB."""
+        if not self.table:
+            raise ValueError(f"Table {self.table_name} not available")
+
+        # Perform vector search
+        results = self.table.search(query_vector).limit(
+            self.k_neighbors).to_pandas()
+        return results
+
+    def response_handler(self, query_vector, blob_data, results, result_blobs):
+        """Handle search results."""
+        if len(results) != self.k_neighbors:
+            raise ValueError(
+                f"Expected {self.k_neighbors} results, got {len(results)}")
+
+
+class LanceDBKNNEngine(KNNEngine):
+    """LanceDB KNN benchmark engine."""
+
+    def __init__(self):
+        super().__init__("ldb")
+
+    def run_benchmark(self, params):
+        """Run KNN benchmark for LanceDB."""
+        import utils as u
+
+        # Use centralized connector from utils
+        db = u.create_connector_lancedb()
+
+        print(f"Connected to LanceDB Cloud")
+        print(f"Available tables: {db.table_names()}")
+
+        eval_tool = self.setup_eval_tool(params)
+        # Use the sizes from parameters, not hardcoded values
+        sizes = params.sizes
+
+        for s in sizes:
+            table_name = f"{params.dataset}_{size_to_str(s)}"
+
+            if table_name not in db.table_names():
+                print(f"Table {table_name} not found, skipping...")
+                continue
+
+            print(f"Running benchmark for size: {size_to_str(s)}")
+
+            # Load query dataset - will now use TEST vectors via updated base class
+            if params.dataset == "deepimage96":
+                query_data = u.DatasetDeepImage96(
+                    max=params.total_queries).test
+            elif params.dataset == "yfcc100m":
+                query_data = u.DatasetYFCC100M(max=params.total_queries).test
+            else:
+                raise ValueError(f"Unknown dataset: {params.dataset}")
+
+            print(f"Using {len(query_data)} test vectors as queries")
+
+            # Create query generator
+            qg = QueryGeneratorLanceDB(
+                n_queries=params.total_queries,
+                table_name=table_name,
+                k_neighbors=params.knn_samples,
+                dataset=params.dataset,
+                db=db
+            )
+            qg.dataset = query_data
+
+            # Collect KNN results for verification (only once per size)
+            print(f"Collecting KNN results for verification...")
+            verification_results = []
+            # Limit to avoid too many results
+            for query_idx in range(min(params.total_queries, 100)):
+                query_vector, _ = qg.getitem(query_idx)
+                results = qg.search(query_vector)
+
+                # Debug: Print the structure of the first result
+                if query_idx == 0:
+                    print(f"LanceDB result structure:")
+                    print(f"  Type: {type(results)}")
+                    print(
+                        f"  Shape: {results.shape if hasattr(results, 'shape') else 'N/A'}")
+                    print(
+                        f"  Columns: {list(results.columns) if hasattr(results, 'columns') else 'N/A'}")
+                    if len(results) > 0:
+                        print(f"  Sample data: {results.head(2)}")
+
+                # Extract neighbor IDs from results - LanceDB typically uses row index or a specific ID column
+                neighbor_ids = []
+                try:
+                    if hasattr(results, 'columns') and len(results) > 0:
+                        # Check for original dataset ID column first (for ground truth comparison)
+                        if 'deep_img_id' in results.columns:
+                            neighbor_ids = results['deep_img_id'].tolist()[
+                                :params.knn_samples]
+                        elif 'id' in results.columns:
+                            neighbor_ids = results['id'].tolist()[
+                                :params.knn_samples]
+                        elif '_rowid' in results.columns:
+                            neighbor_ids = results['_rowid'].tolist()[
+                                :params.knn_samples]
+                        elif len(results.columns) > 0:
+                            # Use the first column as ID (common in vector DBs)
+                            first_col = results.columns[0]
+                            neighbor_ids = results[first_col].tolist()[
+                                :params.knn_samples]
+                        else:
+                            # Use DataFrame index as IDs
+                            neighbor_ids = results.index.tolist()[
+                                :params.knn_samples]
+                    elif hasattr(results, 'to_list'):
+                        # Alternative format
+                        neighbor_ids = results.to_list()[:params.knn_samples]
+                except Exception as e:
+                    print(
+                        f"Error extracting neighbor IDs for query {query_idx}: {e}")
+                    # Fill with zeros as fallback
+                    neighbor_ids = [0] * params.knn_samples
+
+                # Ensure we have the right number of neighbors
+                while len(neighbor_ids) < params.knn_samples:
+                    neighbor_ids.append(0)  # Pad with zeros if needed
+
+                # Debug: Print first few results to understand ID mapping
+                if query_idx < 3:  # Debug first 3 queries
+                    print(
+                        f"    Query {query_idx}: Engine returned {neighbor_ids[:5]}")
+
+                verification_results.append(neighbor_ids[:params.knn_samples])
+
+            # Write results to file for verification
+            if verification_results:
+                print(
+                    f"Writing {len(verification_results)} results to file...")
+                set_name = f"{params.dataset}_{size_to_str(s)}"
+                self.write_results(verification_results, "ldb", set_name)
+
+            # Test different concurrency levels
+            for concurrency in params.concurrencies:
+                print(f"Testing concurrency: {concurrency}")
+
+                def worker_function(worker_id):
+                    """Worker function for concurrent queries."""
+                    times = []
+
+                    queries_per_worker = params.total_queries // concurrency
+                    start_idx = worker_id * queries_per_worker
+
+                    for i in range(queries_per_worker):
+                        query_idx = start_idx + i
+                        if query_idx >= params.total_queries:
+                            break
+
+                        query_vector, _ = qg.getitem(query_idx)
+
+                        start_time = time.time()
+                        results = qg.search(query_vector)
+                        elapsed_time = time.time() - start_time
+
+                        times.append(elapsed_time)
+
+                        # Handle response for validation
+                        qg.response_handler(query_vector, None, results, None)
+
+                    return times
+
+                # Run concurrent queries
+                threads = []
+                all_times = []
+
+                start_total = time.time()
+
+                for worker_id in range(concurrency):
+                    thread = threading.Thread(
+                        target=lambda wid=worker_id: all_times.extend(worker_function(wid)))
+                    threads.append(thread)
+                    thread.start()
+
+                for thread in threads:
+                    thread.join()
+
+                total_time = time.time() - start_total
+                avg_time = np.mean(all_times) if all_times else 0
+                throughput = len(all_times) / \
+                    total_time if total_time > 0 else 0
+
+                print(f"Concurrency {concurrency}: "
+                      f"Avg time: {avg_time:.4f}s, "
+                      f"Throughput: {throughput:.2f} QPS")
+
+                # Log percentiles
+                if all_times:
+                    self.log_percentiles(all_times)
+
+                # Record results using correct EvalTool API
+                knn_times = np.percentile(
+                    all_times, params.stats_percentile) if all_times else 0
+                eval_tool.add_row(
+                    f"knn_{params.knn_samples}",
+                    f"ldb_perc_{params.stats_percentile}",
+                    s,  # size
+                    concurrency,  # concurrency
+                    params.total_queries,
+                    knn_times,  # percentile time
+                    0,  # ith percentile is a single value
+                    params.knn_samples,
+                    0
+                )
+
+        eval_tool.export_to_csv()
+        print("LanceDB benchmark completed!")
+
+
+def run_lancedb_knn(params):
+    """Entry point for LanceDB KNN benchmark."""
+    engine = LanceDBKNNEngine()
+    engine.run_benchmark(params)

--- a/apps/vectordb-compare/app/knn_pinecone.py
+++ b/apps/vectordb-compare/app/knn_pinecone.py
@@ -1,0 +1,109 @@
+"""
+Pinecone KNN Engine Implementation
+"""
+
+import os
+import time
+import threading
+import numpy as np
+
+from knn_base import KNNEngine, QueryGenerator, size_to_str
+import utils as u
+
+
+class QueryGeneratorPinecone(QueryGenerator):
+    """Pinecone specific query generator."""
+
+    def __init__(self, n_queries=int(1e6), k_neighbors=10, dataset="yfcc100m"):
+        super().__init__(n_queries, k_neighbors, dataset)
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        return self.dataset[idx].tolist()
+
+
+def worker_pinecone(index, generator, namespace, knn_samples, start_index, end_index, times, results):
+    """Worker function for Pinecone threading."""
+    for i in range(start_index, end_index + 1):
+        if i >= len(generator):
+            break
+
+        query_vector = generator[i]
+
+        start_time = time.time()
+        response = index.query(
+            namespace=namespace,
+            vector=query_vector,
+            top_k=knn_samples,
+            include_values=False,
+        )
+
+        assert (len(response["matches"]) == knn_samples)
+        times[i] = time.time() - start_time
+
+        for j in range(len(response["matches"])):
+            results[i][j] = int(response["matches"][j]["id"].split("-")[1])
+
+
+class PineconeEngine(KNNEngine):
+    """Pinecone KNN benchmark engine."""
+
+    def __init__(self):
+        super().__init__("pinecone")
+
+    def run_benchmark(self, params, grpc=False):
+        """Run Pinecone KNN benchmark."""
+        pc = u.create_connector_pinecone(grpc=grpc)
+        index_name = f"knn-{params.dataset}"
+        e_knn = self.setup_eval_tool(params)
+
+        for s in params.sizes:
+            namespace = f"{params.dataset}_{size_to_str(s)}"
+
+            for c in params.concurrencies:
+                print(f"Running knn for {namespace} on {c} threads...")
+
+                generator = QueryGeneratorPinecone(params.total_queries, k_neighbors=params.knn_samples,
+                                                   dataset=params.dataset)
+
+                threads = []
+                times = [0.0 for _ in range(len(generator))]
+                results = [[0 for _ in range(params.knn_samples)]
+                           for _ in range(len(generator))]
+
+                th_queue_size = len(generator) // c
+
+                index = pc.Index(index_name)
+                for i in range(c):
+                    start_index = i * len(generator) // c
+                    end_index = min(
+                        start_index + th_queue_size, len(generator))
+
+                    t = threading.Thread(target=worker_pinecone, args=(
+                        index, generator, namespace, params.knn_samples, start_index, end_index, times, results))
+                    threads.append(t)
+                    t.start()
+
+                for t in threads:
+                    t.join()
+
+                engine = "pc_grpc" if grpc else "pc"
+
+                knn_times = np.percentile(
+                    np.array(times), params.stats_percentile)
+                e_knn.add_row(f"knn_{params.knn_samples}", f"{engine}_perc_{params.stats_percentile}", s, c, params.total_queries,
+                              knn_times, 0,  # ith percentile is a single value
+                              params.knn_samples, 0)
+
+                self.log_percentiles(times)
+                self.write_results(results, engine, namespace)
+
+        e_knn.export_to_csv()
+
+
+def run_knn_pinecone(params, grpc=False):
+    """Entry point for Pinecone KNN benchmark."""
+    engine = PineconeEngine()
+    engine.run_benchmark(params, grpc)

--- a/apps/vectordb-compare/app/knn_qdrant.py
+++ b/apps/vectordb-compare/app/knn_qdrant.py
@@ -1,0 +1,112 @@
+"""
+Qdrant KNN Engine Implementation
+"""
+
+import os
+import time
+import threading
+import numpy as np
+
+from knn_base import KNNEngine, QueryGenerator, size_to_str
+import utils as u
+
+
+class QueryGeneratorQdrant(QueryGenerator):
+    """Qdrant specific query generator (same as Pinecone)."""
+
+    def __init__(self, n_queries=int(1e6), k_neighbors=10, dataset="yfcc100m"):
+        super().__init__(n_queries, k_neighbors, dataset)
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        return self.dataset[idx].tolist()
+
+
+def worker_qdrant(client, generator, collection_name, knn_samples, start_index, end_index, times, results):
+    """Worker function for Qdrant threading."""
+    for i in range(start_index, end_index + 1):
+        if i >= len(generator):
+            break
+
+        query_vector = generator[i]
+
+        start_time = time.time()
+        response = client.query_points(
+            collection_name=collection_name,
+            query=query_vector,
+            with_payload=False,
+            limit=knn_samples,
+        ).points
+        assert (len(response) == knn_samples)
+
+        times[i] = time.time() - start_time
+
+        for j in range(len(response)):
+            results[i][j] = response[j].id
+
+
+class QdrantEngine(KNNEngine):
+    """Qdrant KNN benchmark engine."""
+
+    def __init__(self):
+        super().__init__("qdrant")
+
+    def run_benchmark(self, params):
+        """Run Qdrant KNN benchmark."""
+        client = u.create_connector_qdrant()
+        e_knn = self.setup_eval_tool(params)
+
+        for s in params.sizes:
+            collection_name = f"{params.dataset}_{size_to_str(s)}"
+
+            for c in params.concurrencies:
+                print(
+                    f"Running knn for {collection_name} on {c} threads...", flush=True)
+
+                generator = QueryGeneratorQdrant(params.total_queries, k_neighbors=params.knn_samples,
+                                                 dataset=params.dataset)
+
+                start_time = time.time()
+                threads = []
+                times = [0.0 for _ in range(len(generator))]
+                results = [[0 for _ in range(params.knn_samples)]
+                           for _ in range(len(generator))]
+
+                th_queue_size = len(generator) // c
+                for i in range(c):
+                    start_index = i * len(generator) // c
+                    end_index = min(
+                        start_index + th_queue_size, len(generator))
+
+                    t = threading.Thread(
+                        target=worker_qdrant,
+                        args=(client, generator, collection_name, params.knn_samples, start_index,
+                              end_index, times, results))
+                    threads.append(t)
+                    t.start()
+
+                for t in threads:
+                    t.join()
+
+                end_time = time.time()
+                engine = "qd"
+
+                knn_times = np.percentile(
+                    np.array(times), params.stats_percentile)
+                e_knn.add_row(f"knn_{params.knn_samples}", f"{engine}_perc_{params.stats_percentile}", s, c, params.total_queries,
+                              knn_times, 0,  # ith percentile is a single value
+                              params.knn_samples, 0)
+
+                self.log_percentiles(times)
+                self.write_results(results, engine, collection_name)
+
+        e_knn.export_to_csv()
+        client.close()
+
+
+def run_knn_qdrant(params):
+    """Entry point for Qdrant KNN benchmark."""
+    engine = QdrantEngine()
+    engine.run_benchmark(params)

--- a/apps/vectordb-compare/app/knn_weaviate.py
+++ b/apps/vectordb-compare/app/knn_weaviate.py
@@ -1,0 +1,108 @@
+"""
+Weaviate KNN Engine Implementation
+"""
+
+import os
+import time
+import threading
+import numpy as np
+
+from knn_base import KNNEngine, QueryGenerator, size_to_str
+import utils as u
+
+
+class QueryGeneratorWeaviate(QueryGenerator):
+    """Weaviate specific query generator (same as Pinecone)."""
+
+    def __init__(self, n_queries=int(1e6), k_neighbors=10, dataset="yfcc100m"):
+        super().__init__(n_queries, k_neighbors, dataset)
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        return self.dataset[idx].tolist()
+
+
+def worker_weaviate(collection, generator, knn_samples, start_index, end_index, times, results):
+    """Worker function for Weaviate threading."""
+    for i in range(start_index, end_index + 1):
+        if i >= len(generator):
+            break
+
+        query_vector = generator[i]
+
+        start_time = time.time()
+        response = collection.query.near_vector(
+            near_vector=query_vector,
+            limit=knn_samples,
+        )
+        assert (len(response.objects) == knn_samples)
+
+        times[i] = time.time() - start_time
+
+        for j in range(len(response.objects)):
+            results[i][j] = response.objects[j].properties["test"]
+
+
+class WeaviateEngine(KNNEngine):
+    """Weaviate KNN benchmark engine."""
+
+    def __init__(self):
+        super().__init__("weaviate")
+
+    def run_benchmark(self, params):
+        """Run Weaviate KNN benchmark."""
+        client = u.create_connector_weaviate()
+        e_knn = self.setup_eval_tool(params)
+
+        for s in params.sizes:
+            collection_name = f"{params.dataset}_{size_to_str(s)}"
+            collection = client.collections.get(collection_name)
+
+            for c in params.concurrencies:
+                print(f"Running knn for {collection_name} on {c} threads...")
+
+                generator = QueryGeneratorWeaviate(params.total_queries, k_neighbors=params.knn_samples,
+                                                   dataset=params.dataset)
+
+                start_time = time.time()
+                threads = []
+                times = [0.0 for _ in range(len(generator))]
+                results = [[0 for _ in range(params.knn_samples)]
+                           for _ in range(len(generator))]
+
+                th_queue_size = len(generator) // c
+                for i in range(c):
+                    start_index = i * len(generator) // c
+                    end_index = min(
+                        start_index + th_queue_size, len(generator))
+
+                    t = threading.Thread(target=worker_weaviate, args=(
+                        collection, generator, params.knn_samples, start_index, end_index, times, results))
+                    threads.append(t)
+                    t.start()
+
+                for t in threads:
+                    t.join()
+
+                end_time = time.time()
+                engine = "wv"  # Use consistent engine name matching command line
+
+                knn_times = np.percentile(
+                    np.array(times), params.stats_percentile)
+                e_knn.add_row(f"knn_{params.knn_samples}", f"{engine}_perc_{params.stats_percentile}", s, c, params.total_queries,
+                              knn_times, 0,  # ith percentile is a single value
+                              params.knn_samples, 0)
+
+                self.log_percentiles(times)
+                self.write_results(results, engine, collection_name)
+
+        e_knn.export_to_csv()
+        client.close()
+
+
+def run_knn_weaviate(params):
+    """Entry point for Weaviate KNN benchmark."""
+    engine = WeaviateEngine()
+    engine.run_benchmark(params)

--- a/apps/vectordb-compare/app/plot.py
+++ b/apps/vectordb-compare/app/plot.py
@@ -1,0 +1,37 @@
+import os
+import argparse
+
+from dbeval import EvalTool
+
+
+def main(params):
+
+    # # Insertion
+    # eval_name = os.path.join(params.output_folder, "descriptors_insert")
+    # e_insert = EvalTool.EvalTool(eval_name)
+    # e_insert.plot_all(folder=os.path.join(params.output_folder, "plots_insert"))
+
+    # Query
+    eval_name = os.path.join(params.output_folder, "knn_comp")
+    e_knn = EvalTool.EvalTool(eval_name)
+    e_knn.plot_n_res_scale = "x"
+    e_knn.plot_query_time_scale = "x"
+    e_knn.plot_query_throughput_scale = "x"
+    e_knn.plot_n_res_throughput_scale = "x"
+    e_knn.plot_all(folder=os.path.join(params.output_folder, "plots_knn"))
+
+
+def get_args():
+    obj = argparse.ArgumentParser()
+
+    obj.add_argument('-output_folder', type=str,  default="output")
+    obj.add_argument('-verbose',       type=bool, default=True)
+
+    params = obj.parse_args()
+
+    return params
+
+
+if __name__ == "__main__":
+    args = get_args()
+    main(args)

--- a/apps/vectordb-compare/app/test.sh
+++ b/apps/vectordb-compare/app/test.sh
@@ -1,0 +1,5 @@
+sudo rm -rf output/*
+
+python3 knn.py -knn_samples=10
+
+python3 plot.py

--- a/apps/vectordb-compare/app/utils.py
+++ b/apps/vectordb-compare/app/utils.py
@@ -1,0 +1,186 @@
+import os
+import h5py
+import numpy as np
+
+
+def write_results_to_file(results, engine, index_name):
+
+    top_k = len(results[0])
+    f = open(f"output/results_{engine}_{index_name}_top{top_k}.txt", "w")
+    for i in range(len(results)):
+        for j in range(len(results[i])):
+            str_id = results[i][j]
+            f.write(f"{str_id:>8}")
+        f.write(f"\n")
+    f.close()
+
+
+def print_percentiles(times, percentiles=None):
+
+    if percentiles is None:
+        percentiles = [10, 50, 90, 95, 99]
+
+    for p in percentiles:
+        print(f"    Percentile {p}: {np.percentile(np.array(times), p)}")
+    print(f"    Average time:  {np.mean(times)}")
+
+
+def create_connector_pinecone(grpc=False):
+    """Create Pinecone connector with dynamic import."""
+    api_key = os.environ.get("PINECONE_API_KEY", "")
+
+    if api_key is None:
+        raise Exception("API_KEY_PINECONE not set")
+
+    if grpc:
+        from pinecone import PineconeGRPC as Pinecone
+        pc = Pinecone(api_key=api_key)
+    else:
+        from pinecone import Pinecone
+        pc = Pinecone(api_key=api_key)
+
+    return pc
+
+
+def create_connector_weaviate():
+    """Create Weaviate connector with dynamic import."""
+    import weaviate
+    from weaviate.classes.init import Auth
+
+    cluster_url = os.environ.get("WEAVIATE_CLUSTER_URL", "")
+    api_key     = os.environ.get("WEAVIATE_API_KEY", "")
+
+    if cluster_url is None:
+        raise Exception("WEAVIATE_CLUSTER_URL not set")
+
+    if api_key is None:
+        raise Exception("WEAVIATE_API_KEY not set")
+
+    client = weaviate.connect_to_weaviate_cloud(
+        cluster_url=cluster_url,
+        auth_credentials=Auth.api_key(api_key),
+    )
+
+    return client
+
+
+def create_connector_qdrant():
+    """Create Qdrant connector with dynamic import."""
+    from qdrant_client import QdrantClient
+
+    cluster_url = os.environ.get("QDRANT_CLUSTER_URL", "")
+    api_key     = os.environ.get("QDRANT_API_KEY", "")
+
+    if cluster_url is None:
+        raise Exception("QDRANT_URL not set")
+
+    if api_key is None:
+        raise Exception("QDRANT_API_KEY not set")
+
+    client = QdrantClient(url=cluster_url, api_key=api_key)
+
+    return client
+
+
+def create_connector_lancedb():
+    """Create LanceDB connector with dynamic import."""
+    import lancedb
+
+    # Use LanceDB Cloud with API key
+    lancedb_key = os.environ.get('LANCEDB_API_KEY')
+    if not lancedb_key:
+        raise ValueError(
+            "LANCEDB_API_KEY environment variable is required for cloud connection")
+
+    # Get database URI from environment or use default cloud format
+    db_uri = os.environ.get('LANCEDB_URI', 'db://default')
+
+    db = lancedb.connect(db_uri, api_key=lancedb_key)
+
+    return db
+
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise Exception('Boolean value expected.')
+
+
+class Dataset():
+
+    def __init__(self, max=None):
+
+        if max is not None:
+            self.max = max
+
+        self.len = self.max
+
+    def getitem(self, idx):
+        if idx < 0 or self.len <= idx:
+            return None
+
+        # Return the ith descriptor
+        return self.dataset[idx]
+
+    def __len__(self):
+        return self.len
+
+
+class DatasetDeepImage96(Dataset):
+
+    def __init__(self, max=None):
+
+        self.name = "deep-image-96-angular"
+        self.path = f"input/{self.name}.hdf5"
+        self.dim  = 96
+        self.max  = 9_990_000
+
+        if max is not None and max < self.max:
+            self.max = max
+
+        # print(f"Loading {self.path} ...")
+        with h5py.File(self.path, "r") as f:
+
+            self.distances = f["distances"][()]
+            self.neighbors = f["neighbors"][()]
+            self.test      = f["test"][()]
+            self.dataset   = f["train"][()]
+
+        # print(f"Done.")
+
+        if max is not None and max < len(self.dataset):
+            self.dataset = self.dataset[:max]
+
+        self.len = len(self.dataset)
+
+        assert (len(self.dataset) == self.len)
+        assert (len(self.dataset[0]) == self.dim)
+
+
+class DatasetYFCC100M(Dataset):
+
+    def __init__(self, max=None):
+
+        self.name = "yfcc100m"
+        self.path = "input/YFCC100M_hybridCNN_gmean_fc6_0.bin"
+        self.dim  = 4096
+        self.max  = 1_000_000
+
+        if max is not None and max < self.max:
+            self.max = max
+
+        self.len = self.max
+
+        # print(f"Loading {self.path} ...")
+        dtype = [('id', np.int64), ('descs', np.float32, (self.dim))]
+        with open(self.path, 'rb') as fh:
+            self.dataset = np.fromfile(fh, dtype, count=self.len)["descs"]
+        # print(f"Done.")
+
+        assert (len(self.dataset) == self.len)
+        assert (len(self.dataset[0]) == self.dim)

--- a/apps/vectordb-compare/app/verify.py
+++ b/apps/vectordb-compare/app/verify.py
@@ -1,0 +1,186 @@
+"""
+Main Ingestion Verification Runner with Dynamic Engine Loading
+"""
+
+import argparse
+import os
+import importlib
+import time
+from config import create_config_from_args
+
+
+def load_verification_engine(engine_name):
+    """
+    Dynamically load verification engine module to avoid import issues when engine is not used.
+    """
+    engine_mapping = {
+        'adb': 'verify_aperturedb',
+        'pc': 'verify_pinecone',
+        'wv': 'verify_weaviate',
+        'qd': 'verify_qdrant',
+        'ldb': 'verify_lancedb'
+    }
+
+    module_name = engine_mapping.get(engine_name)
+    if not module_name:
+        raise ValueError(f"Unknown engine: {engine_name}")
+
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        print(f"Failed to import engine {engine_name}: {e}")
+        print(f"Skipping {engine_name} - required dependencies not available")
+        return None
+
+
+def run_engine_verification(engine_name, source, size_str, dim, size_count):
+    """Run verification for a specific engine and return timing info."""
+    module = load_verification_engine(engine_name)
+    if not module:
+        return False, 0.0
+
+    print(
+        f"Verifying {engine_name} - {source}_{size_str} ({size_count:,} vectors)...")
+    start_time = time.time()
+
+    try:
+        if engine_name == 'adb':
+            result = module.verify_aperturedb(
+                f"{source}_{size_str}", dim, size_count)
+        elif engine_name == 'pc':
+            result = module.verify_pinecone(
+                source, f"{source}_{size_str}", dim, size_count)
+        elif engine_name == 'wv':
+            result = module.verify_weaviate(
+                f"{source}_{size_str}", dim, size_count)
+        elif engine_name == 'qd':
+            result = module.verify_qdrant(
+                f"{source}_{size_str}", dim, size_count)
+        elif engine_name == 'ldb':
+            result = module.verify_lancedb(
+                f"{source}_{size_str}", dim, size_count)
+        else:
+            return False, 0.0
+
+        elapsed_time = time.time() - start_time
+        status = "✅ PASSED" if result else "❌ FAILED"
+        print(f"  {status} - Query time: {elapsed_time:.3f}s")
+
+        return result, elapsed_time
+
+    except Exception as e:
+        elapsed_time = time.time() - start_time
+        print(f"  ❌ ERROR: {e} - Query time: {elapsed_time:.3f}s")
+        return False, elapsed_time
+
+
+def main(params):
+    """Main verification runner with dynamic engine loading."""
+    # Determine correct dimensions based on dataset
+    if params.dataset == "deepimage96":
+        params.dim = 96
+    elif params.dataset == "yfcc100m":
+        params.dim = 4096
+
+    print(f"Verifying {params.dataset} dataset ({params.dim} dimensions)")
+    print("=" * 80)
+
+    sizes = ["1k", "10k", "100k", "1m"]
+    all_good = True
+    size_count = 1000
+
+    # Track timing data for summary table
+    timing_data = {}
+    verification_results = {}
+
+    for size_str in sizes:
+        print(
+            f"\n📊 Verifying dataset size: {size_str} ({size_count:,} vectors)")
+        timing_data[size_str] = {}
+        verification_results[size_str] = {}
+
+        for engine in params.engines:
+            result, elapsed_time = run_engine_verification(
+                engine, params.dataset, size_str, params.dim, size_count)
+
+            timing_data[size_str][engine] = elapsed_time
+            verification_results[size_str][engine] = result
+            all_good &= result
+
+        size_count *= 10
+
+    # Display verification timing summary table
+    display_timing_summary(
+        timing_data, verification_results, params.engines, sizes)
+
+    if all_good:
+        print(f"\n✅ Verification passed for {params.dataset}")
+    else:
+        print(f"\n❌ ERROR: Verification failed for {params.dataset}")
+
+    return all_good
+
+
+def display_timing_summary(timing_data, verification_results, engines, sizes):
+    """Display a summary table of verification timing and results."""
+    print("\n" + "=" * 80)
+    print("VERIFICATION TIMING SUMMARY")
+    print("=" * 80)
+
+    # Header
+    print(f"{'Dataset Size':<12}", end="")
+    for engine in engines:
+        print(f"{engine.upper():<12}", end="")
+    print()
+
+    print("-" * (12 + len(engines) * 12))
+
+    # Data rows
+    for size_str in sizes:
+        print(f"{size_str:<12}", end="")
+        for engine in engines:
+            if engine in timing_data[size_str]:
+                elapsed = timing_data[size_str][engine]
+                success = verification_results[size_str][engine]
+                status_symbol = "✅" if success else "❌"
+                print(f"{elapsed:.3f}s {status_symbol:<6}", end="")
+            else:
+                print(f"{'N/A':<12}", end="")
+        print()
+
+    # Summary statistics
+    print("\n📈 TIMING STATISTICS:")
+    total_times = {}
+    for engine in engines:
+        engine_times = []
+        for size_str in sizes:
+            if engine in timing_data[size_str]:
+                engine_times.append(timing_data[size_str][engine])
+
+        if engine_times:
+            total_time = sum(engine_times)
+            avg_time = total_time / len(engine_times)
+            max_time = max(engine_times)
+            min_time = min(engine_times)
+
+            print(f"  {engine.upper():<5}: Total: {total_time:.3f}s | Avg: {avg_time:.3f}s | Min: {min_time:.3f}s | Max: {max_time:.3f}s")
+            total_times[engine] = total_time
+
+    # Fastest/slowest engines
+    if total_times:
+        fastest_engine = min(total_times.keys(), key=lambda x: total_times[x])
+        slowest_engine = max(total_times.keys(), key=lambda x: total_times[x])
+        print(
+            f"\n🏃 Fastest Engine: {fastest_engine.upper()} ({total_times[fastest_engine]:.3f}s total)")
+        print(
+            f"🐢 Slowest Engine: {slowest_engine.upper()} ({total_times[slowest_engine]:.3f}s total)")
+
+
+def get_args():
+    """Parse command line arguments using centralized config."""
+    return create_config_from_args("verify")
+
+
+if __name__ == "__main__":
+    args = get_args()
+    main(args)

--- a/apps/vectordb-compare/app/verify_aperturedb.py
+++ b/apps/vectordb-compare/app/verify_aperturedb.py
@@ -1,0 +1,39 @@
+"""
+ApertureDB Ingestion Verification Engine
+"""
+
+from verify_base import VerificationEngine
+
+# ApertureDB imports - only imported when this module is used
+from aperturedb import CommonLibrary
+
+
+class ApertureDBVerificationEngine(VerificationEngine):
+    """ApertureDB ingestion verification engine."""
+
+    def __init__(self):
+        super().__init__("adb")
+
+    def verify_ingestion(self, collection_name, dims, expected_elements, **kwargs):
+        """Verify ApertureDB ingestion."""
+        db = CommonLibrary.create_connector()
+
+        response, _ = db.query([{
+            "FindDescriptorSet": {
+                "with_name": collection_name,
+                "results": {
+                    "all_properties": True,
+                }
+            }
+        }])
+
+        elements = response[0]["FindDescriptorSet"]["entities"][0]["_count"]
+        success = elements == expected_elements
+
+        return self.log_result(collection_name, expected_elements, elements, success)
+
+
+def verify_aperturedb(set_name, dims, expected_elements):
+    """Entry point for ApertureDB ingestion verification."""
+    engine = ApertureDBVerificationEngine()
+    return engine.verify_ingestion(set_name, dims, expected_elements)

--- a/apps/vectordb-compare/app/verify_base.py
+++ b/apps/vectordb-compare/app/verify_base.py
@@ -1,0 +1,29 @@
+"""
+Base classes and shared utilities for ingestion verification engines.
+"""
+
+import os
+from abc import ABC, abstractmethod
+
+
+class VerificationEngine(ABC):
+    """Abstract base class for ingestion verification engines."""
+
+    def __init__(self, engine_name):
+        self.engine_name = engine_name
+
+    @abstractmethod
+    def verify_ingestion(self, collection_name, dims, expected_elements, **kwargs):
+        """Verify ingestion for this engine."""
+        pass
+
+    def log_result(self, collection_name, expected, actual, success):
+        """Log verification result."""
+        if success:
+            print(
+                f"Verifying {self.engine_name.ljust(3)} {collection_name}... OK")
+        else:
+            print(
+                f"Verifying {self.engine_name.ljust(3)} {collection_name}... FAILED")
+            print(f"  Expected: {expected}, Got: {actual}")
+        return success

--- a/apps/vectordb-compare/app/verify_lancedb.py
+++ b/apps/vectordb-compare/app/verify_lancedb.py
@@ -1,0 +1,85 @@
+"""
+LanceDB Ingestion Verification Engine
+"""
+
+import os
+from verify_base import VerificationEngine
+
+
+class LanceDBVerificationEngine(VerificationEngine):
+    """LanceDB ingestion verification engine."""
+
+    def __init__(self):
+        super().__init__("ldb")
+
+    def verify_ingestion(self, collection_name, dims, expected_elements, **kwargs):
+        """Verify LanceDB ingestion."""
+        import utils as u
+
+        # Use centralized connector from utils
+        db = u.create_connector_lancedb()
+
+        try:
+            # Check if table exists
+            if collection_name not in db.table_names():
+                print(f"Error: Table {collection_name} not found")
+                return self.log_result(collection_name, expected_elements, 0, False)
+
+            # Open table and count rows
+            table = db.open_table(collection_name)
+
+            # Use count() method or search to get row count (LanceDB Cloud compatible)
+            try:
+                # Try to get count using count() method if available
+                actual_count = table.count_rows()
+            except AttributeError:
+                # Fallback: use search to estimate count
+                try:
+                    # Search for all rows to get count
+                    all_results = table.search().limit(expected_elements + 1000).to_list()
+                    actual_count = len(all_results)
+                except Exception as search_error:
+                    # Final fallback: try a simple search to see if table has any data
+                    try:
+                        sample_results = table.search().limit(1).to_list()
+                        if sample_results:
+                            print(f"Warning: Cannot determine exact row count for {collection_name}. "
+                                  f"Table exists and has data but verification method failed: {search_error}")
+                            return self.log_result(collection_name, expected_elements, -1, False)
+                        else:
+                            # Empty table
+                            actual_count = 0
+                    except Exception as final_error:
+                        print(
+                            f"Error: Cannot access table data for {collection_name}: {final_error}")
+                        return self.log_result(collection_name, expected_elements, -1, False)
+
+            # Verify vector dimensions if possible
+            if actual_count > 0:
+                try:
+                    # Get a sample row using search
+                    sample_results = table.search().limit(1).to_list()
+                    if sample_results and len(sample_results) > 0:
+                        sample_row = sample_results[0]
+                        if 'vector' in sample_row:
+                            actual_dims = len(sample_row['vector'])
+                            if actual_dims != dims:
+                                print(
+                                    f"Error: Dimension mismatch: expected {dims}, got {actual_dims}")
+                                return self.log_result(collection_name, expected_elements, actual_count, False)
+                except Exception as dim_error:
+                    print(f"Warning: Could not verify dimensions: {dim_error}")
+                    # Continue without dimension check
+
+            success = actual_count == expected_elements
+            return self.log_result(collection_name, expected_elements, actual_count, success)
+
+        except Exception as e:
+            print(f"Error: {str(e)}")
+            return self.log_result(collection_name, expected_elements, 0, False)
+
+
+def verify_lancedb(set_name, dims, expected_elements):
+    """Entry point for LanceDB ingestion verification."""
+    engine = LanceDBVerificationEngine()
+    return engine.verify_ingestion(set_name, dims, expected_elements)

--- a/apps/vectordb-compare/app/verify_pinecone.py
+++ b/apps/vectordb-compare/app/verify_pinecone.py
@@ -1,0 +1,32 @@
+"""
+Pinecone Ingestion Verification Engine
+"""
+
+from verify_base import VerificationEngine
+import utils as u
+
+
+class PineconeVerificationEngine(VerificationEngine):
+    """Pinecone ingestion verification engine."""
+
+    def __init__(self):
+        super().__init__("pc")
+
+    def verify_ingestion(self, collection_name, dims, expected_elements, dataset=None, **kwargs):
+        """Verify Pinecone ingestion."""
+        pc = u.create_connector_pinecone(grpc=False)
+
+        index_name = f"knn-{dataset}"
+        index = pc.Index(index_name)
+
+        elements = index.describe_index_stats(
+        )["namespaces"][collection_name]["vector_count"]
+        success = elements == expected_elements
+
+        return self.log_result(collection_name, expected_elements, elements, success)
+
+
+def verify_pinecone(dataset, namespace, dims, expected_elements):
+    """Entry point for Pinecone ingestion verification."""
+    engine = PineconeVerificationEngine()
+    return engine.verify_ingestion(namespace, dims, expected_elements, dataset=dataset)

--- a/apps/vectordb-compare/app/verify_qdrant.py
+++ b/apps/vectordb-compare/app/verify_qdrant.py
@@ -1,0 +1,31 @@
+"""
+Qdrant Ingestion Verification Engine
+"""
+
+from verify_base import VerificationEngine
+import utils as u
+
+
+class QdrantVerificationEngine(VerificationEngine):
+    """Qdrant ingestion verification engine."""
+
+    def __init__(self):
+        super().__init__("qd")
+
+    def verify_ingestion(self, collection_name, dims, expected_elements, **kwargs):
+        """Verify Qdrant ingestion."""
+        client = u.create_connector_qdrant()
+
+        collection = client.get_collection(collection_name)
+        elements = collection.points_count
+
+        client.close()
+
+        success = elements == expected_elements
+        return self.log_result(collection_name, expected_elements, elements, success)
+
+
+def verify_qdrant(collection_name, dims, expected_elements):
+    """Entry point for Qdrant ingestion verification."""
+    engine = QdrantVerificationEngine()
+    return engine.verify_ingestion(collection_name, dims, expected_elements)

--- a/apps/vectordb-compare/app/verify_weaviate.py
+++ b/apps/vectordb-compare/app/verify_weaviate.py
@@ -1,0 +1,32 @@
+"""
+Weaviate Ingestion Verification Engine
+"""
+
+from verify_base import VerificationEngine
+import utils as u
+
+
+class WeaviateVerificationEngine(VerificationEngine):
+    """Weaviate ingestion verification engine."""
+
+    def __init__(self):
+        super().__init__("wv")
+
+    def verify_ingestion(self, collection_name, dims, expected_elements, **kwargs):
+        """Verify Weaviate ingestion."""
+        client = u.create_connector_weaviate()
+
+        collection = client.collections.get(collection_name)
+        response = collection.aggregate.over_all(total_count=True)
+        elements = response.total_count
+
+        client.close()
+
+        success = elements == expected_elements
+        return self.log_result(collection_name, expected_elements, elements, success)
+
+
+def verify_weaviate(collection_name, dims, expected_elements):
+    """Entry point for Weaviate ingestion verification."""
+    engine = WeaviateVerificationEngine()
+    return engine.verify_ingestion(collection_name, dims, expected_elements)

--- a/apps/vectordb-compare/compose.yml
+++ b/apps/vectordb-compare/compose.yml
@@ -1,0 +1,13 @@
+services:
+  bench-vectordb-compare:
+    build:
+      context: .
+      args:
+        - APP_NAME=wf-bench-vectordb-compare
+    image: aperturedata/wf-bench-vectordb-compare
+    network_mode: host
+    volumes:
+      - ./input:/app/input/
+      - ./output:/app/output/
+    env_file:
+      - .env

--- a/apps/vectordb-compare/requirements.txt
+++ b/apps/vectordb-compare/requirements.txt
@@ -1,0 +1,19 @@
+pandas
+numpy
+h5py
+
+urllib3
+pkginfo
+pydantic
+pydantic_core
+
+aperturedb
+dbeval
+
+pinecone
+qdrant-client
+lancedb
+
+# Weaviate client requires protobuf==6.30.0 to work properly
+# protobuf==6.30.0
+# weaviate-client

--- a/apps/vectordb-compare/test.sh
+++ b/apps/vectordb-compare/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+source $(dirname "$0")/../../tests/utils.sh
+cleanup_docker
+
+run_local_aperturedb
+
+docker run --name $WORKFLOWNAME \
+           --network $DOCKERNETWORK \
+           -e RUN_NAME=ci_test \
+           -e DB_HOST=aperturedb \
+           -e USE_SSL=false \
+           -e MINIMAL=true \
+           -e PUSH_TO_S3=true \
+           -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+           -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+           -v ./input:/app/input/ \
+           aperturedata/wf-$WORKFLOWNAME


### PR DESCRIPTION
## Description
This PR ports the `vectordb-compare` app from the internal workflows repository and fixes critical discrepancies in how the benchmarks measured database latency:

### Fixes
1. **KNN Query Generation Out-of-Timer**: Previously, the query payload generation (e.g. `query_vector = generator[i]`) happened inside the measured `start_time` - `end_time` block for most databases, and in the case of ApertureDB it was being evaluated twice per iteration. This PR moves the payload extraction outside the `time.time()` block for all databases (ApertureDB, Pinecone, Qdrant, Weaviate), guaranteeing that the benchmark accurately measures database query latency, unpolluted by Python data generation overhead.
2. **Ingestion Timing Synchronization**: Fixed ingestion measurements so that data preparation is included symmetrically across all databases:
    - **LanceDB**: Moved the `records` construction inside the `time.time()` block.
    - **Qdrant**: Changed `wait=False` to `wait=True` on the `upsert` call to ensure the benchmark measures synchronous persistence, making it fair when compared to Weaviate, Pinecone, and ApertureDB.

These fixes make the performance results across all vectors databases truly comparable.